### PR TITLE
Use safePackageName to name file

### DIFF
--- a/src/createRollupConfig.js
+++ b/src/createRollupConfig.js
@@ -32,7 +32,7 @@ export function createRollupConfig(format, env, opts) {
     // Establish Rollup output
     output: {
       // Set filenames of the consumer's package
-      file: `${paths.appDist}/${safeVariableName(
+      file: `${paths.appDist}/${safePackageName(
         opts.name
       )}.${format}.${env}.js`,
       // Pass through the file format


### PR DESCRIPTION
Close #35 

This addresses the kebab/camel issue. Note: The UMD variable name will still be camelcased. 