### PR TITLE
remove async; fix test

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -487,7 +487,7 @@ prog
   .option('--write-file', 'Write the config file locally')
   .example('lint --write-file')
   .action(
-    async (opts: {
+    (opts: {
       fix: boolean;
       'ignore-pattern': string;
       'write-file': boolean;

--- a/test/tests/lint/tsdx-lint.test.js
+++ b/test/tests/lint/tsdx-lint.test.js
@@ -47,7 +47,7 @@ describe('tsdx lint', () => {
   it('should not lint', () => {
     const output = shell.exec(`node dist/index.js lint`);
     expect(output.code).toBe(1);
-    expect(output.toString()).toContain('No input files specified.');
+    expect(output.toString()).toContain('No input files specified, defaulting to src test');
   });
 
   describe('when --write-file is used', () => {


### PR DESCRIPTION
1. remove `aynsc` from `lint` CLI command. having `async` there swallows errors, and isn't necessary because no `await` is used.
2. tests were broken, fixed.