### PR TITLE
Use `@wessberg/rollup-plugin-ts` + change output naming structure

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@babel/preset-env": "^7.4.4",
     "@typescript-eslint/eslint-plugin": "^2.3.1",
     "@typescript-eslint/parser": "^2.3.1",
+    "@wessberg/rollup-plugin-ts": "^1.1.64",
     "ansi-escapes": "^3.2.0",
     "asyncro": "^3.0.0",
     "babel-eslint": "^10.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1909,8 +1909,8 @@ packages:
   /browserslist/4.7.0:
     dependencies:
       caniuse-lite: 1.0.30000997
-      electron-to-chromium: 1.3.268
-      node-releases: 1.1.32
+      electron-to-chromium: 1.3.269
+      node-releases: 1.1.33
     dev: false
     hasBin: true
     resolution:
@@ -2571,10 +2571,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=
-  /electron-to-chromium/1.3.268:
+  /electron-to-chromium/1.3.269:
     dev: false
     resolution:
-      integrity: sha512-QkPEya233zGh+1erw/N/GNgLjs+t65wkGX4Yw0X/ZuO75r+4Ropk7toXSUqP3TQ7EIwBDotTks3rbNZ1Kwz8hA==
+      integrity: sha512-t2ZTfo07HxkxTOUbIwMmqHBSnJsC9heqJUm7LwQu2iSk0wNhG4H5cMREtb8XxeCrQABDZ6IqQKY3yZq+NfAqwg==
   /elliptic/6.5.1:
     dependencies:
       bn.js: 4.11.8
@@ -4683,12 +4683,12 @@ packages:
     dev: false
     resolution:
       integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
-  /magic-string/0.25.3:
+  /magic-string/0.25.4:
     dependencies:
       sourcemap-codec: 1.4.6
     dev: false
     resolution:
-      integrity: sha512-6QK0OpF/phMz0Q2AxILkX2mFhi7m+WMwTRg0LQKq/WBB0cDP4rYH3Wp4/d3OTXlrPLVJT/RFqj8tFeAR4nk8AA==
+      integrity: sha512-oycWO9nEVAP2RVPbIoDoA4Y7LFIJ3xRYov93gAyJhZkET1tNuB0u7uWkZS2LpBWTJUWnmau/To8ECWRC+jKNfw==
   /make-dir/2.1.0:
     dependencies:
       pify: 4.0.1
@@ -4981,12 +4981,12 @@ packages:
     dev: false
     resolution:
       integrity: sha512-M4UBGcs4jeOK9CjTsYwkvH6/MzuUmGCyTW+kCY7uO+1ZVr0+FHGdPdIf5CCLqAaxnRrWidyoQlNkMIIVwbKB8Q==
-  /node-releases/1.1.32:
+  /node-releases/1.1.33:
     dependencies:
       semver: 5.7.1
     dev: false
     resolution:
-      integrity: sha512-VhVknkitq8dqtWoluagsGPn3dxTvN9fwgR59fV3D7sLBHe0JfDramsMI8n8mY//ccq/Kkrf8ZRHRpsyVZ3qw1A==
+      integrity: sha512-I0V30bWQEoHb+10W8oedVoUrdjW5wIkYm0w7vvcrPO95pZY738m1k77GF5sO0vKg5eXYg9oGtrMAETbgZGm11A==
   /normalize-package-data/2.5.0:
     dependencies:
       hosted-git-info: 2.8.4
@@ -5981,7 +5981,7 @@ packages:
     dependencies:
       estree-walker: 0.6.1
       is-reference: 1.1.4
-      magic-string: 0.25.3
+      magic-string: 0.25.4
       resolve: 1.12.0
       rollup: 1.22.0
       rollup-pluginutils: 2.8.2
@@ -6011,7 +6011,7 @@ packages:
       integrity: sha512-jUlyaDXts7TW2CqQ4GaO5VJ4PwwaV8VUGA7+km3n6k6xtOEacf61u0VXwN80phY/evMcaS+9eIeJ9MOyDxt5Zw==
   /rollup-plugin-replace/2.2.0:
     dependencies:
-      magic-string: 0.25.3
+      magic-string: 0.25.4
       rollup-pluginutils: 2.8.2
     dev: false
     resolution:
@@ -7321,4 +7321,4 @@ specifiers:
   tiny-glob: ^0.2.6
   ts-jest: ^24.0.2
   tslib: ^1.9.3
-  typescript: ^3.4.5
+  typescript: ^3.6.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ dependencies:
   '@babel/preset-env': 7.6.2_@babel+core@7.6.2
   '@typescript-eslint/eslint-plugin': 2.3.1_ac41138cf9733b74a32fde028fe2f96f
   '@typescript-eslint/parser': 2.3.1_eslint@6.5.0
+  '@wessberg/rollup-plugin-ts': 1.1.64_rollup@1.22.0+typescript@3.6.3
   ansi-escapes: 3.2.0
   asyncro: 3.0.0
   babel-eslint: 10.0.3_eslint@6.5.0
@@ -655,6 +656,18 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-fz43fqW8E1tAB3DKF19/vxbpib1fuyCwSPE418ge5ZxILnBhWyhtPgz8eh1RCGGJlwvksHkyxMxh0eenFi+kFw==
+  /@babel/plugin-transform-runtime/7.6.2_@babel+core@7.6.2:
+    dependencies:
+      '@babel/core': 7.6.2
+      '@babel/helper-module-imports': 7.0.0
+      '@babel/helper-plugin-utils': 7.0.0
+      resolve: 1.12.0
+      semver: 5.7.1
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-cqULw/QB4yl73cS5Y0TZlQSjDvNkzDbu0FurTZyHlJpWE5T3PCMdnyV+xXoH1opr1ldyHODe3QAX3OMAii5NxA==
   /@babel/plugin-transform-shorthand-properties/7.2.0_@babel+core@7.6.2:
     dependencies:
       '@babel/core': 7.6.2
@@ -1084,7 +1097,6 @@ packages:
   /@types/mkdirp/0.5.2:
     dependencies:
       '@types/node': 12.7.8
-    dev: true
     resolution:
       integrity: sha512-U5icWpv7YnZYGsN4/cmh3WD2onMY0aJIiTE6+51TwJCttdHvtCYmkBNOobHlXwrJRL0nkH9jH4kD+1FAdMN4Tg==
   /@types/ms/0.7.31:
@@ -1098,6 +1110,10 @@ packages:
     dev: true
     resolution:
       integrity: sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==
+  /@types/object-path/0.11.0:
+    dev: false
+    resolution:
+      integrity: sha512-/tuN8jDbOXcPk+VzEVZzzAgw1Byz7s/itb2YI10qkSyy6nykJH02DuhfrflxVdAdE7AZ91h5X6Cn0dmVdFw2TQ==
   /@types/ora/3.2.0:
     dependencies:
       ora: 3.4.0
@@ -1136,10 +1152,18 @@ packages:
     dev: true
     resolution:
       integrity: sha512-dqF1rMFy4O8yNlQYwYPos5Cfav0f6M7PLH8B33gsslQ0zA9MX1jMGokwNuJ3Z3EXAzsKF/xAWNHpFmELcgYJww==
+  /@types/semver/6.0.2:
+    dev: false
+    resolution:
+      integrity: sha512-G1Ggy7/9Nsa1Jt2yiBR2riEuyK2DFNnqow6R7cromXPMNynackRY1vqFTLz/gwnef1LHokbXThcPhqMRjUbkpQ==
   /@types/stack-utils/1.0.1:
     dev: false
     resolution:
       integrity: sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
+  /@types/ua-parser-js/0.7.33:
+    dev: false
+    resolution:
+      integrity: sha512-ngUKcHnytUodUCL7C6EZ+lVXUjTMQb+9p/e1JjV5tN9TVzS98lHozWEFRPY1QcCdwFeMsmVWfZ3DPPT/udCyIw==
   /@types/yargs-parser/13.1.0:
     dev: false
     resolution:
@@ -1334,6 +1358,65 @@ packages:
     dev: false
     resolution:
       integrity: sha512-w0U0pD4EhlnvRyeJzBqaVSJAo9w/ce7/WPogeXLzGkO6hzhr4GnQIZ4W4uUt5b9ooAaXPtnXlj0gzsXEOUNYMg==
+  /@wessberg/browserslist-generator/1.0.23:
+    dependencies:
+      '@types/object-path': 0.11.0
+      '@types/semver': 6.0.2
+      '@types/ua-parser-js': 0.7.33
+      browserslist: 4.6.2
+      caniuse-lite: 1.0.30000974
+      mdn-browser-compat-data: 0.0.84
+      object-path: 0.11.4
+      semver: 6.3.0
+      ua-parser-js: 0.7.20
+    dev: false
+    engines:
+      node: '>=9.0.0'
+    resolution:
+      integrity: sha512-QP6p7Gr+/sRu/NBqhxdNuFeWLdJVrKYURELw+RX8IADPZ0N3mwoSBP7cHgsC+lMVBf0UiinS/TquLuPMLczRhw==
+  /@wessberg/rollup-plugin-ts/1.1.64_rollup@1.22.0+typescript@3.6.3:
+    dependencies:
+      '@babel/core': 7.6.2
+      '@babel/plugin-proposal-async-generator-functions': 7.2.0_@babel+core@7.6.2
+      '@babel/plugin-proposal-json-strings': 7.2.0_@babel+core@7.6.2
+      '@babel/plugin-proposal-object-rest-spread': 7.6.2_@babel+core@7.6.2
+      '@babel/plugin-proposal-optional-catch-binding': 7.2.0_@babel+core@7.6.2
+      '@babel/plugin-proposal-unicode-property-regex': 7.6.2_@babel+core@7.6.2
+      '@babel/plugin-syntax-dynamic-import': 7.2.0_@babel+core@7.6.2
+      '@babel/plugin-transform-runtime': 7.6.2_@babel+core@7.6.2
+      '@babel/preset-env': 7.6.2_@babel+core@7.6.2
+      '@babel/runtime': 7.6.2
+      '@types/mkdirp': 0.5.2
+      '@types/node': 12.7.8
+      '@types/resolve': 0.0.8
+      '@wessberg/browserslist-generator': 1.0.23
+      '@wessberg/stringutil': 1.0.18
+      browserslist: 4.6.6
+      find-up: 4.1.0
+      magic-string: 0.25.4
+      mkdirp: 0.5.1
+      resolve: 1.12.0
+      rollup: 1.22.0
+      rollup-pluginutils: 2.8.2
+      slash: 3.0.0
+      tslib: 1.10.0
+      typescript: 3.6.3
+    dev: false
+    engines:
+      node: '>=9.0.0'
+    peerDependencies:
+      rollup: ^1.x
+      typescript: ^3.x
+    resolution:
+      integrity: sha512-Ch6ZNfsnpFVkIV8JqKpkMt+0fDTHOIIVFSoqQc46z/wl7PibwNUXCv/mTt3pKvVyJdVQ8fSaoevJo/pUzhQKxQ==
+  /@wessberg/stringutil/1.0.18:
+    dependencies:
+      tslib: 1.10.0
+    dev: false
+    engines:
+      node: '>=9.0.0'
+    resolution:
+      integrity: sha512-nIVMm7P5OKyVjxdQb8vuklqi2aXNS6FtdXhp28Ot6aUF/4BDO09u9xJKDpKHQXjkQ3g0bApjPuBij6MrARNUBA==
   /@xtuc/ieee754/1.2.0:
     dev: false
     resolution:
@@ -1906,6 +1989,24 @@ packages:
     dev: false
     resolution:
       integrity: sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==
+  /browserslist/4.6.2:
+    dependencies:
+      caniuse-lite: 1.0.30000997
+      electron-to-chromium: 1.3.269
+      node-releases: 1.1.33
+    dev: false
+    hasBin: true
+    resolution:
+      integrity: sha512-2neU/V0giQy9h3XMPwLhEY3+Ao0uHSwHvU8Q1Ea6AgLVL1sXbX3dzPrJ8NWe5Hi4PoTkCYXOtVR9rfRLI0J/8Q==
+  /browserslist/4.6.6:
+    dependencies:
+      caniuse-lite: 1.0.30000997
+      electron-to-chromium: 1.3.269
+      node-releases: 1.1.33
+    dev: false
+    hasBin: true
+    resolution:
+      integrity: sha512-D2Nk3W9JL9Fp/gIcWei8LrERCS+eXu9AM5cfXA8WEZ84lFks+ARnZ0q/R69m2SV3Wjma83QDDPxsNKXUwdIsyA==
   /browserslist/4.7.0:
     dependencies:
       caniuse-lite: 1.0.30000997
@@ -2040,6 +2141,10 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
+  /caniuse-lite/1.0.30000974:
+    dev: false
+    resolution:
+      integrity: sha512-xc3rkNS/Zc3CmpMKuczWEdY2sZgx09BkAxfvkxlAEBTqcMHeL8QnPqhKse+5sRTi3nrw2pJwToD2WvKn1Uhvww==
   /caniuse-lite/1.0.30000997:
     dev: false
     resolution:
@@ -3181,7 +3286,6 @@ packages:
     dependencies:
       locate-path: 5.0.0
       path-exists: 4.0.0
-    dev: true
     engines:
       node: '>=8'
     resolution:
@@ -4618,7 +4722,6 @@ packages:
   /locate-path/5.0.0:
     dependencies:
       p-locate: 4.1.0
-    dev: true
     engines:
       node: '>=8'
     resolution:
@@ -4738,6 +4841,14 @@ packages:
     dev: false
     resolution:
       integrity: sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==
+  /mdn-browser-compat-data/0.0.84:
+    dependencies:
+      extend: 3.0.2
+    dev: false
+    engines:
+      node: '>=8.0.0'
+    resolution:
+      integrity: sha512-fAznuGNaQMQiWLVf+gyp33FaABTglYWqMT7JqvH+4RZn2UQPD12gbMqxwP9m0lj8AAbNpu5/kD6n4Ox1SOffpw==
   /memory-fs/0.4.1:
     dependencies:
       errno: 0.1.7
@@ -5049,6 +5160,12 @@ packages:
       node: '>= 0.4'
     resolution:
       integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
+  /object-path/0.11.4:
+    dev: false
+    engines:
+      node: '>=0.10.0'
+    resolution:
+      integrity: sha1-NwrnUvvzfePqcKhhwju6iRVpGUk=
   /object-visit/1.0.1:
     dependencies:
       isobject: 3.0.1
@@ -5216,7 +5333,6 @@ packages:
   /p-locate/4.1.0:
     dependencies:
       p-limit: 2.2.1
-    dev: true
     engines:
       node: '>=8'
     resolution:
@@ -5326,7 +5442,6 @@ packages:
     resolution:
       integrity: sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=
   /path-exists/4.0.0:
-    dev: true
     engines:
       node: '>=8'
     resolution:
@@ -6279,7 +6394,6 @@ packages:
     resolution:
       integrity: sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==
   /slash/3.0.0:
-    dev: true
     engines:
       node: '>=8'
     resolution:
@@ -6864,6 +6978,10 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==
+  /ua-parser-js/0.7.20:
+    dev: false
+    resolution:
+      integrity: sha512-8OaIKfzL5cpx8eCMAhhvTlft8GYF8b2eQr6JkCyVdrgjcytyOmPCXrqXFcUnhonRpLlh5yxEZVohm6mzaowUOw==
   /uglify-js/3.6.0:
     dependencies:
       commander: 2.20.1
@@ -7268,6 +7386,7 @@ specifiers:
   '@types/rollup-plugin-sourcemaps': ^0.4.2
   '@typescript-eslint/eslint-plugin': ^2.3.1
   '@typescript-eslint/parser': ^2.3.1
+  '@wessberg/rollup-plugin-ts': ^1.1.64
   ansi-escapes: ^3.2.0
   asyncro: ^3.0.0
   babel-eslint: ^10.0.3

--- a/src/createRollupConfig.ts
+++ b/src/createRollupConfig.ts
@@ -9,7 +9,7 @@ import replace from 'rollup-plugin-replace';
 import resolve from 'rollup-plugin-node-resolve';
 import sourceMaps from 'rollup-plugin-sourcemaps';
 import { ScriptTarget, JsxEmit } from 'typescript';
-import typescript from '@wessberg/rollup-plugin-ts';
+import ts from '@wessberg/rollup-plugin-ts';
 import { extractErrors } from './errors/extractErrors';
 import { babelPluginTsdx } from './babelPluginTsdx';
 import { TsdxOptions } from './types';
@@ -125,8 +125,8 @@ export function createRollupConfig(opts: TsdxOptions) {
         },
       },
       opts.format === 'esm' && !shouldMinify
-        ? typescript({
-            transpiler: 'typescript',
+        ? ts({
+            transpiler: 'babel',
             tsconfig: tsconfig => ({
               ...tsconfig,
               target: ScriptTarget.ESNext,
@@ -136,8 +136,8 @@ export function createRollupConfig(opts: TsdxOptions) {
               jsx: JsxEmit.React,
             }),
           })
-        : typescript({
-            transpiler: 'typescript',
+        : ts({
+            transpiler: 'babel',
             tsconfig: tsconfig => ({
               ...tsconfig,
               target: ScriptTarget.ESNext,

--- a/src/createRollupConfig.ts
+++ b/src/createRollupConfig.ts
@@ -8,11 +8,8 @@ import json from 'rollup-plugin-json';
 import replace from 'rollup-plugin-replace';
 import resolve from 'rollup-plugin-node-resolve';
 import sourceMaps from 'rollup-plugin-sourcemaps';
-
 import { ScriptTarget, JsxEmit } from 'typescript';
 import typescript from '@wessberg/rollup-plugin-ts';
-
-// import typescript from 'rollup-plugin-typescript2';
 import { extractErrors } from './errors/extractErrors';
 import { babelPluginTsdx } from './babelPluginTsdx';
 import { TsdxOptions } from './types';
@@ -149,23 +146,6 @@ export function createRollupConfig(opts: TsdxOptions) {
               jsx: JsxEmit.React,
             }),
           }),
-      // typescript({
-      //   typescript: require('typescript'),
-      //   cacheRoot: `./.rts2_cache_${opts.format}`,
-      //   tsconfig: opts.tsconfig,
-      //   tsconfigDefaults: {
-      //     compilerOptions: {
-      //       sourceMap: true,
-      //       declaration: true,
-      //       jsx: 'react',
-      //     },
-      //   },
-      //   tsconfigOverride: {
-      //     compilerOptions: {
-      //       target: 'esnext',
-      //     },
-      //   },
-      // }),
       babelPluginTsdx({
         exclude: 'node_modules/**',
         extensions: [...DEFAULT_EXTENSIONS, 'ts', 'tsx'],

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,11 +13,6 @@ export const safeVariableName = (name: string) =>
       .replace(/((^[^a-zA-Z]+)|[^\w.-])|([^a-zA-Z0-9]+$)/g, '')
   );
 
-// export const safePackageName = (name: string) =>
-//   name
-//     .toLowerCase()
-//     .replace(/(^@.*\/)|((^[^a-zA-Z]+)|[^\w.-])|([^a-zA-Z0-9]+$)/g, '');
-
 export const external = (id: string) =>
   !id.startsWith('.') && !path.isAbsolute(id);
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,10 +13,10 @@ export const safeVariableName = (name: string) =>
       .replace(/((^[^a-zA-Z]+)|[^\w.-])|([^a-zA-Z0-9]+$)/g, '')
   );
 
-export const safePackageName = (name: string) =>
-  name
-    .toLowerCase()
-    .replace(/(^@.*\/)|((^[^a-zA-Z]+)|[^\w.-])|([^a-zA-Z0-9]+$)/g, '');
+// export const safePackageName = (name: string) =>
+//   name
+//     .toLowerCase()
+//     .replace(/(^@.*\/)|((^[^a-zA-Z]+)|[^\w.-])|([^a-zA-Z0-9]+$)/g, '');
 
 export const external = (id: string) =>
   !id.startsWith('.') && !path.isAbsolute(id);

--- a/test/tests/tsdx-build.test.js
+++ b/test/tests/tsdx-build.test.js
@@ -1,7 +1,6 @@
 /**
  * @jest-environment node
  */
-'use strict';
 
 const shell = require('shelljs');
 const util = require('../fixtures/util');
@@ -21,15 +20,11 @@ describe('tsdx build', () => {
     const output = shell.exec('node ../dist/index.js build --format esm,cjs');
 
     expect(shell.test('-f', 'dist/index.js')).toBeTruthy();
-    expect(
-      shell.test('-f', 'dist/build-default.cjs.development.js')
-    ).toBeTruthy();
-    expect(
-      shell.test('-f', 'dist/build-default.cjs.production.min.js')
-    ).toBeTruthy();
-    expect(shell.test('-f', 'dist/build-default.esm.js')).toBeTruthy();
+    expect(shell.test('-f', 'dist/cjs/index.js')).toBeTruthy();
+    expect(shell.test('-f', 'dist/cjs/index.min.js')).toBeTruthy();
+    expect(shell.test('-f', 'dist/esm/index.js')).toBeTruthy();
 
-    expect(shell.test('-f', 'dist/index.d.ts')).toBeTruthy();
+    expect(shell.test('-f', 'dist/types/index.d.ts')).toBeTruthy();
 
     expect(output.code).toBe(0);
   });

--- a/test/tests/utils-safePackageName.test.ts
+++ b/test/tests/utils-safePackageName.test.ts
@@ -1,9 +1,0 @@
-const { safePackageName } = require('../../src/utils');
-
-describe('utils | safePackageName', () => {
-  it('should generate safe package name', () => {
-    expect(safePackageName('@babel/core')).toBe('core');
-    expect(safePackageName('react')).toBe('react');
-    expect(safePackageName('react-dom')).toBe('react-dom');
-  });
-});


### PR DESCRIPTION
Addresses #208 and #200.

- Switch the output naming structure/convention. We are kind of forced to do that to make a better and more predictable experience, and integrating this plugin.
- Update `tsdx create` according to new output structure; Plus, correct "package generation". Currently, if user type `@hela/core` in the prompt it will create `core` folder in the `cwd` and also will add to the generated package.json file a name field to be `core` instead `@hela/core`, which definitely isn't correct behavior. 
- Remove the "utils safePackageName" test.
- Remove the safePackageName function, at all.
- ESLint autofix is enabled on my VSCode, so ESLint removed the `use strict` on the `tsdx-build.test.js`, obviously according to the given eslint config and prettier.
- Immediately before I started anything with just `pnpm i` on fresh branch, the pnpm's lockfile changed.

The only left is to update the `babelPluginTsdx` file, meaning to drop the `rollup-plugin-babel` dependency and just generate babel config and pass it as `babelConfig` option to the ts plugin. But keep in mind the ts plugin also automatically includes some plugins and does merging some default options.