### PR TITLE
Add system to list of supported formats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules
 .rts2_cache_cjs
 .rts2_cache_esm
 .rts2_cache_umd
+.rts2_cache_system
 dist
 tester
 tester-react

--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ export interface TsdxOptions {
   // JS target
   target: 'node' | 'browser';
   // Module format
-  format: 'cjs' | 'umd' | 'esm';
+  format: 'cjs' | 'umd' | 'esm' | 'system';
   // Environment
   env: 'development' | 'production';
   // Path to tsconfig file

--- a/src/index.ts
+++ b/src/index.ts
@@ -133,6 +133,18 @@ function createBuildConfigs(
           env: 'production',
           input,
         },
+        opts.format.includes('system') && {
+          ...opts,
+          format: 'system',
+          env: 'development',
+          input,
+        },
+        opts.format.includes('system') && {
+          ...opts,
+          format: 'system',
+          env: 'production',
+          input,
+        },
       ]
         .filter(Boolean)
         .map((options: TsdxOptions, index: number) => ({

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,7 @@ export interface TsdxOptions {
   // JS target
   target: 'node' | 'browser';
   // Module format
-  format: 'cjs' | 'umd' | 'esm';
+  format: 'cjs' | 'umd' | 'esm' | 'system';
   // Environment
   env: 'development' | 'production';
   // Path to tsconfig file

--- a/templates/basic/gitignore
+++ b/templates/basic/gitignore
@@ -4,4 +4,5 @@ node_modules
 .rts2_cache_cjs
 .rts2_cache_esm
 .rts2_cache_umd
+.rts2_cache_system
 dist

--- a/templates/react/gitignore
+++ b/templates/react/gitignore
@@ -5,4 +5,5 @@ node_modules
 .rts2_cache_cjs
 .rts2_cache_esm
 .rts2_cache_umd
+.rts2_cache_system
 dist

--- a/website/docs/customization.md
+++ b/website/docs/customization.md
@@ -30,7 +30,7 @@ export interface TsdxOptions {
   // JS target
   target: 'node' | 'browser';
   // Module format
-  format: 'cjs' | 'umd' | 'esm';
+  format: 'cjs' | 'umd' | 'esm' | 'system';
   // Environment
   env: 'development' | 'production';
   // Path to tsconfig file


### PR DESCRIPTION
We need support for SystemJS format because we would like to load generated bundle through SystemJS.

Hopefully, I haven't missed changing something. :blush: 

I've tested just basic scenario and it seems okay. Not sure how to test it on some complex scenario.