### PR TITLE
fix(testing): add support for jest.config.js

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,4 +9,5 @@ export const paths = {
   appErrors: resolveApp('errors'),
   appDist: resolveApp('dist'),
   appConfig: resolveApp('tsdx.config.js'),
+  jestConfig: resolveApp('jest.config'),
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,5 +9,5 @@ export const paths = {
   appErrors: resolveApp('errors'),
   appDist: resolveApp('dist'),
   appConfig: resolveApp('tsdx.config.js'),
-  jestConfig: resolveApp('jest.config'),
+  jestConfig: resolveApp('jest.config.js'),
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -469,10 +469,7 @@ prog
     };
     try {
       // Allow overriding with jest.config
-      const jestConfigContents = require(path.resolve(
-        paths.appRoot,
-        'jest.config.js'
-      ));
+      const jestConfigContents = require(paths.jestConfig);
       jestConfig = { ...jestConfig, ...jestConfigContents };
     } catch {}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -460,15 +460,26 @@ prog
     });
 
     const argv = process.argv.slice(2);
+    let jestConfig = {
+      ...createJestConfig(
+        relativePath => path.resolve(__dirname, '..', relativePath),
+        paths.appRoot
+      ),
+      ...appPackageJson.jest,
+    };
+    try {
+      // Allow overriding with jest.config
+      const jestConfigContents = require(path.resolve(
+        paths.appRoot,
+        'jest.config.js'
+      ));
+      jestConfig = { ...jestConfig, ...jestConfigContents };
+    } catch {}
 
     argv.push(
       '--config',
       JSON.stringify({
-        ...createJestConfig(
-          relativePath => path.resolve(__dirname, '..', relativePath),
-          paths.appRoot
-        ),
-        ...appPackageJson.jest,
+        ...jestConfig,
       })
     );
 


### PR DESCRIPTION
Currently, `jest.config.js` is ignored. My fix is to try and check if there is a `jest.config.js`, if so then we just merge it into the jestConfig. 

This fixes #100 . 

Issue #150 is in a similar vein to this but that needs some more work. 