### PR TITLE
fix: failing builds

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -24,7 +24,7 @@ jobs:
         run: npm install -g yarn
 
       - name: Install deps and build
-        run: yarn install --frozen-lockfile
+        run: yarn install --frozen-lockfile --ignore-engines
 
       - name: Test package
         run: yarn test


### PR DESCRIPTION
Using the `--ignore-engines` flag when installing with yarn https://yarnpkg.com/en/docs/cli/install#toc-yarn-install-ignore-engines

This is necessitated by one of the deps we rely on, `rollup-plugin-ts`, having a node >= 9.0.0 engine requirement which is failing the nodejs 8 builds.

https://github.com/wessberg/rollup-plugin-ts/blob/9079d7a4705078e0709a6f5b9b5147081cce7baf/package.json#L108-L110

To view the github actions error see https://github.com/jaredpalmer/tsdx/runs/259520250#step:5:7