### PR TITLE
Use dist path config

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -441,7 +441,7 @@ async function normalizeOpts(opts: any) {
 }
 
 function ensureDistFolder() {
-  return util.promisify(mkdirp)(resolveApp('dist'));
+  return util.promisify(mkdirp)(paths.appDist);
 }
 
 function cleanDistFolder() {
@@ -461,7 +461,7 @@ if (process.env.NODE_ENV === 'production') {
   ${baseLine}.cjs.development.js')
 }
 `;
-  return fs.writeFile(resolveApp(`./dist/index.js`), contents);
+  return fs.writeFile(path.join(paths.appDist, 'index.js'), contents);
 }
 
 prog


### PR DESCRIPTION
### Changelog

- Use `paths.appDist` in places where we need to refer to the `dist` folder.