### PR TITLE
Improve package json template

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -257,7 +257,7 @@ prog
         main: 'dist/index.js',
         module: `dist/${safeName}.esm.js`,
         typings: `dist/index.d.ts`,
-        files: ['dist'],
+        files: ['dist', 'src'],
         scripts: {
           start: 'tsdx watch',
           build: 'tsdx build',


### PR DESCRIPTION
Since source maps point to `../src/*` if people don't publish the `src` folder, source maps are not that useful.