### PR TITLE
Fix logger integration

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -14,5 +14,5 @@ export const paths = {
   appDist: resolveApp('dist'),
   appConfig: resolveApp('tsdx.config.js'),
   jestConfig: resolveApp('jest.config.js'),
-  storagePath: path.join(cache, '.progress-estimator'),
+  progressEstimatorCache: path.join(cache, '.progress-estimator'),
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,14 +1,18 @@
+import path from 'path';
 import { resolveApp } from './utils';
+
+const cache = resolveApp('node_modules/.cache');
 
 export const paths = {
   appPackageJson: resolveApp('package.json'),
   testsSetup: resolveApp('test/setupTests.ts'),
   appRoot: resolveApp('.'),
-  cache: resolveApp('node_modules/.cache'),
+  cache,
   appSrc: resolveApp('src'),
   appErrorsJson: resolveApp('errors/codes.json'),
   appErrors: resolveApp('errors'),
   appDist: resolveApp('dist'),
   appConfig: resolveApp('tsdx.config.js'),
   jestConfig: resolveApp('jest.config.js'),
+  storagePath: path.join(cache, '.progress-estimator'),
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,12 +34,18 @@ import getInstallArgs from './getInstallArgs';
 import { Input, Select } from 'enquirer';
 import { TsdxOptions } from './types';
 const pkg = require('../package.json');
-const createLogger = require('progress-estimator');
-// All configuration keys are optional, but it's recommended to specify a storage location.
-// Learn more about configuration options below.
-const logger = createLogger({
-  storagePath: path.join(paths.cache, '.progress-estimator'),
-});
+const progressEstimator = require('progress-estimator');
+
+function createLogger() {
+  mkdirp.sync(paths.storagePath);
+  return progressEstimator({
+    // All configuration keys are optional, but it's recommended to specify a storage location.
+    // Learn more about configuration options below.
+    storagePath: paths.storagePath,
+  });
+}
+
+const logger = createLogger();
 
 const prog = sade('tsdx');
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,11 +37,11 @@ const pkg = require('../package.json');
 const progressEstimator = require('progress-estimator');
 
 function createLogger() {
-  mkdirp.sync(paths.storagePath);
+  mkdirp.sync(paths.progressEstimatorCache);
   return progressEstimator({
     // All configuration keys are optional, but it's recommended to specify a storage location.
     // Learn more about configuration options below.
-    storagePath: paths.storagePath,
+    storagePath: paths.progressEstimatorCache,
   });
 }
 


### PR DESCRIPTION
### Changelog

- Moved storage path into paths configuration
- Fixed progress logger integration. It creates the storage folder since `.cache` folder inside `node_modules` may be missing and the package doesn't resolve this issue