### PR TITLE
Lazily initialize progress estimator cache

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,18 +1,14 @@
-import path from 'path';
 import { resolveApp } from './utils';
-
-const cache = resolveApp('node_modules/.cache');
 
 export const paths = {
   appPackageJson: resolveApp('package.json'),
   testsSetup: resolveApp('test/setupTests.ts'),
   appRoot: resolveApp('.'),
-  cache,
   appSrc: resolveApp('src'),
   appErrorsJson: resolveApp('errors/codes.json'),
   appErrors: resolveApp('errors'),
   appDist: resolveApp('dist'),
   appConfig: resolveApp('tsdx.config.js'),
   jestConfig: resolveApp('jest.config.js'),
-  progressEstimatorCache: path.join(cache, '.progress-estimator'),
+  progressEstimatorCache: resolveApp('node_modules/.cache/.progress-estimator'),
 };

--- a/src/createProgressEstimator.ts
+++ b/src/createProgressEstimator.ts
@@ -1,0 +1,13 @@
+import { paths } from './constants';
+import util from 'util';
+import mkdirp from 'mkdirp';
+const progressEstimator = require('progress-estimator');
+
+export async function createProgressEstimator() {
+  await util.promisify(mkdirp)(paths.progressEstimatorCache);
+  return progressEstimator({
+    // All configuration keys are optional, but it's recommended to specify a storage location.
+    // Learn more about configuration options below.
+    storagePath: paths.progressEstimatorCache,
+  });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,19 +33,8 @@ import getInstallCmd from './getInstallCmd';
 import getInstallArgs from './getInstallArgs';
 import { Input, Select } from 'enquirer';
 import { TsdxOptions } from './types';
+import { createProgressEstimator } from './createProgressEstimator';
 const pkg = require('../package.json');
-const progressEstimator = require('progress-estimator');
-
-function createLogger() {
-  mkdirp.sync(paths.progressEstimatorCache);
-  return progressEstimator({
-    // All configuration keys are optional, but it's recommended to specify a storage location.
-    // Learn more about configuration options below.
-    storagePath: paths.progressEstimatorCache,
-  });
-}
-
-const logger = createLogger();
 
 const prog = sade('tsdx');
 
@@ -407,6 +396,7 @@ prog
     const buildConfigs = createBuildConfigs(opts);
     await cleanDistFolder();
     await ensureDistFolder();
+    const logger = await createProgressEstimator();
     if (opts.format.includes('cjs')) {
       const promise = writeCjsEntryFile(opts.name).catch(logError);
       logger(promise, 'Creating entry file');


### PR DESCRIPTION
This only creates the progress estimator cache during `tsdx build` instead of on every single run. It also makes is async.

Continuation of #256 