### PR TITLE
Added support for eslint report

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,6 +442,7 @@ Options
   --fix               Fixes fixable errors and warnings
   --ignore-pattern    Ignore a pattern
   --write-file        Write the config file locally
+  --report-file       Write JSON report to file locally
   -h, --help          Displays this message
 
 Examples
@@ -449,6 +450,7 @@ Examples
   $ tsdx lint src --fix
   $ tsdx lint src test --ignore-pattern test/foo.ts
   $ tsdx lint src --write-file
+  $ tsdx lint src --report-file report.json
 ```
 
 ## Author

--- a/src/index.ts
+++ b/src/index.ts
@@ -576,11 +576,14 @@ prog
   .example('lint src test --ignore-pattern test/foobar.ts')
   .option('--write-file', 'Write the config file locally')
   .example('lint --write-file')
+  .option('--report-file', 'Write JSON report to file locally')
+  .example('lint --report-file eslint-report.json')
   .action(
     (opts: {
       fix: boolean;
       'ignore-pattern': string;
       'write-file': boolean;
+      'report-file': string;
       _: string[];
     }) => {
       if (opts['_'].length === 0 && !opts['write-file']) {
@@ -610,6 +613,14 @@ prog
         CLIEngine.outputFixes(report);
       }
       console.log(cli.getFormatter()(report.results));
+      if (opts['report-file']) {
+        fs.mkdirsSync(path.dirname(opts['report-file']));
+
+        fs.writeFileSync(
+          opts['report-file'],
+          cli.getFormatter('json')(report.results)
+        );
+      }
       if (report.errorCount) {
         process.exit(1);
       }


### PR DESCRIPTION
I've added new flag `--report-file report.json` to `tsdx lint` which is the same as `eslint -f json -o report.json`.

e.g. `tsdx lint src --report-file report.json`