### PR TITLE
--noClean option for watch

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,7 @@ Options
   --format              Specify module format(s)  (default cjs,esm)
   --tsconfig            Specify your custom tsconfig path (default <root-folder>/tsconfig.json)
   --verbose             Keep outdated console output in watch mode instead of clearing the screen
+  --noClean             Don't clean the dist folder
   -h, --help            Displays this message
 
 Examples
@@ -395,7 +396,8 @@ Examples
   $ tsdx watch --target node
   $ tsdx watch --name Foo
   $ tsdx watch --format cjs,esm,umd
-  $ tsdx build --tsconfig ./tsconfig.foo.json
+  $ tsdx watch --tsconfig ./tsconfig.foo.json
+  $ tsdx watch --noClean
 ```
 
 ### `tsdx build`

--- a/src/index.ts
+++ b/src/index.ts
@@ -354,6 +354,8 @@ prog
     'Keep outdated console output in watch mode instead of clearing the screen'
   )
   .example('watch --verbose')
+  .option('--noClean', "Don't clean the dist folder")
+  .example('watch --noClean')
   .option('--tsconfig', 'Specify custom tsconfig path')
   .example('watch --tsconfig ./tsconfig.foo.json')
   .option('--extractErrors', 'Extract invariant errors to ./errors/codes.json.')
@@ -361,7 +363,9 @@ prog
   .action(async (dirtyOpts: any) => {
     const opts = await normalizeOpts(dirtyOpts);
     const buildConfigs = createBuildConfigs(opts);
-    await cleanDistFolder();
+    if (!opts.noClean) {
+      await cleanDistFolder();
+    }
     await ensureDistFolder();
     if (opts.format.includes('cjs')) {
       await writeCjsEntryFile(opts.name);


### PR DESCRIPTION
When using the lib in development in a yarn workspace, the first step to clean the dist folder trigger the webpack watcher (of CRA or react-native for example) which fail to recompile. This option will enable the smoother workflow for developing side by side a library with an app. 

Related discussions:
- https://github.com/jaredpalmer/tsdx/pull/272#issuecomment-543836283
- https://github.com/jaredpalmer/tsdx/issues/223#issuecomment-541956974

Notes:
- I didn't add it for build because I don't see any use case for that.
- I choose `--noClean` instead of `--no-clean` for consistency with `--extractErrors`