### PR TITLE
Remove confusing comment

### DIFF
--- a/src/createProgressEstimator.ts
+++ b/src/createProgressEstimator.ts
@@ -7,7 +7,6 @@ export async function createProgressEstimator() {
   await util.promisify(mkdirp)(paths.progressEstimatorCache);
   return progressEstimator({
     // All configuration keys are optional, but it's recommended to specify a storage location.
-    // Learn more about configuration options below.
     storagePath: paths.progressEstimatorCache,
   });
 }


### PR DESCRIPTION
The line removed didn't make sense in the context of this source.

It appears to have been copied from https://github.com/bvaughn/progress-estimator/blob/master/README.md#usage-example (in the context of the README it made more sense).