### PR TITLE
fix(lint): do not output warning about react on non-react projects

### DIFF
--- a/src/createEslintConfig.ts
+++ b/src/createEslintConfig.ts
@@ -1,15 +1,23 @@
 import fs from 'fs';
 import path from 'path';
 import { CLIEngine } from 'eslint';
+import { PackageJson } from './types';
+import { getReactVersion } from './utils';
 
 interface CreateEslintConfigArgs {
+  pkg: PackageJson;
   rootDir: string;
   writeFile: boolean;
 }
 export function createEslintConfig({
+  pkg,
   rootDir,
   writeFile,
 }: CreateEslintConfigArgs): CLIEngine.Options['baseConfig'] {
+  const isReactLibrary = Boolean(getReactVersion(pkg));
+
+  console.log(isReactLibrary);
+
   const config = {
     extends: [
       'react-app',

--- a/src/createEslintConfig.ts
+++ b/src/createEslintConfig.ts
@@ -25,7 +25,7 @@ export function createEslintConfig({
     settings: {
       react: {
         // Fix for https://github.com/jaredpalmer/tsdx/issues/279
-        version: !isReactLibrary ? '999.999.999' : undefined,
+        version: isReactLibrary ? 'detect' : '999.999.999',
       },
     },
   };

--- a/src/createEslintConfig.ts
+++ b/src/createEslintConfig.ts
@@ -16,14 +16,18 @@ export function createEslintConfig({
 }: CreateEslintConfigArgs): CLIEngine.Options['baseConfig'] {
   const isReactLibrary = Boolean(getReactVersion(pkg));
 
-  console.log(isReactLibrary);
-
   const config = {
     extends: [
       'react-app',
       'prettier/@typescript-eslint',
       'plugin:prettier/recommended',
     ],
+    settings: {
+      react: {
+        // Fix for https://github.com/jaredpalmer/tsdx/issues/279
+        version: !isReactLibrary ? '999.999.999' : undefined,
+      },
+    },
   };
 
   if (writeFile) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,18 +33,13 @@ import { concatAllArray } from 'jpjs';
 import getInstallCmd from './getInstallCmd';
 import getInstallArgs from './getInstallArgs';
 import { Input, Select } from 'enquirer';
-import { TsdxOptions } from './types';
+import { PackageJson, TsdxOptions } from './types';
 import { createProgressEstimator } from './createProgressEstimator';
 const pkg = require('../package.json');
 
 const prog = sade('tsdx');
 
-let appPackageJson: {
-  name: string;
-  source?: string;
-  jest?: any;
-  eslint?: any;
-};
+let appPackageJson: PackageJson;
 
 try {
   appPackageJson = fs.readJSONSync(resolveApp('package.json'));
@@ -606,6 +601,7 @@ prog
       const cli = new CLIEngine({
         baseConfig: {
           ...createEslintConfig({
+            pkg: appPackageJson,
             rootDir: paths.appRoot,
             writeFile: opts['write-file'],
           }),

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,3 +18,12 @@ export interface TsdxOptions {
   // Is this the very first rollup config (and thus should one-off metadata be extracted)?
   writeMeta?: boolean;
 }
+
+export interface PackageJson {
+  name: string;
+  source?: string;
+  jest?: any;
+  eslint?: any;
+  dependencies?: { [packageName: string]: string };
+  devDependencies?: { [packageName: string]: string };
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,7 @@
 import fs from 'fs-extra';
 import path from 'path';
 import camelCase from 'camelcase';
+import { PackageJson } from './types';
 
 // Remove the package name scope if it exists
 export const removeScope = (name: string) => name.replace(/^@.*\//, '');
@@ -33,5 +34,15 @@ export const resolveApp = function(relativePath: string) {
 export function clearConsole() {
   process.stdout.write(
     process.platform === 'win32' ? '\x1B[2J\x1B[0f' : '\x1B[2J\x1B[3J\x1B[H'
+  );
+}
+
+export function getReactVersion({
+  dependencies,
+  devDependencies,
+}: PackageJson) {
+  return (
+    (dependencies && dependencies.react) ||
+    (devDependencies && devDependencies.react)
   );
 }


### PR DESCRIPTION
**Current behavior:**
We get a warning about detecting React version using the `lint` command in non-react projects.

**New behavior:**
Using the shared settings and the same value used by `eslint-plugin-react` [internally](https://github.com/yannickcr/eslint-plugin-react/blob/master/lib/util/version.js#L29) - it could be almost any value, but I chose this one, we don't get the warning on non-react projects. Closes #279.

**How to reproduce:**
- Use `tsdx lint` inside a react and a non-react project;
- No warning is displayed on both cases.

**Notes:**
N/A.