### PR TITLE
Fixed path in example

### DIFF
--- a/templates/react/example/index.tsx
+++ b/templates/react/example/index.tsx
@@ -1,7 +1,7 @@
 import 'react-app-polyfill/ie11';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { Thing } from '../.';
+import { Thing } from '../src';
 
 const App = () => {
   return (


### PR DESCRIPTION
I'm not sure if I'm missing something, but the import in `index.tsx` in the react example directory does not point to a valid location. It points to the package root, when I think it should point to either `src/index.tsx` or `dist/index.tsx` (but probably the former).