### PR TITLE
(change): use node_modules/.cache/... as cacheRoot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,6 @@
 *.log
 .DS_Store
 node_modules
-.rts2_cache_cjs
-.rts2_cache_esm
-.rts2_cache_umd
-.rts2_cache_system
 dist
 tester
 tester-react

--- a/src/createRollupConfig.ts
+++ b/src/createRollupConfig.ts
@@ -128,7 +128,7 @@ export function createRollupConfig(opts: TsdxOptions) {
       },
       typescript({
         typescript: require('typescript'),
-        cacheRoot: `./.rts2_cache_${opts.format}`,
+        cacheRoot: `./node_modules/.cache/tsdx/${opts.format}/`,
         tsconfig: opts.tsconfig,
         tsconfigDefaults: {
           compilerOptions: {

--- a/templates/basic/gitignore
+++ b/templates/basic/gitignore
@@ -1,8 +1,4 @@
 *.log
 .DS_Store
 node_modules
-.rts2_cache_cjs
-.rts2_cache_esm
-.rts2_cache_umd
-.rts2_cache_system
 dist

--- a/templates/react/gitignore
+++ b/templates/react/gitignore
@@ -2,8 +2,4 @@
 .DS_Store
 node_modules
 .cache
-.rts2_cache_cjs
-.rts2_cache_esm
-.rts2_cache_umd
-.rts2_cache_system
 dist


### PR DESCRIPTION
- instead of outputting these to app root and requiring users to
  gitignore these directories, just output to node_modules/.cache/
  - rollup-plugin-typescript2 is the default cache directory [1], so this
    initially appended _${opts.format} to it
    - upon code review, changed it to tsdx/${opts.format}/
    - babel-loader similarly uses node_modules/.cache/babel-loader [2]
      as its default cache directory and does not allow users to
      change it
      - parcel uses node_modules/.cache/parcel too [3]
      - fuse-box uses node_modules/.fusebox [4]

[1]: https://github.com/ezolenko/rollup-plugin-typescript2#plugin-options > `cacheRoot`
[2]: https://github.com/babel/babel-loader#options > `cacheDirectory`
[3]: https://github.com/parcel-bundler/parcel#caching
[4]: https://github.com/fuse-box/fuse-box/blob/master/docs/getting-started/get-started.md#caching
<hr>

Fixes #328 . Not sure if this change makes sense as, per the issue, I don't know / couldn't find the rationale for using the app root `.rts2_cache_*` directories. I'm also not sure if just removing the `cacheRoot` option and using the default may cause issues -- I'm assuming the `${opts.format}` is there because it does, so I left it in while moving the cache into `node_modules`.

Feel free to close if this doesn't make sense, #328 is more of a question, but I figure I might as well make the small changes I suggested for it in case it does.