### PR TITLE
Add prepare script to generated project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ node_modules
 dist
 tester
 tester-react
+package-lock.json
 # Local Netlify folder
 .netlify

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Despite all the recent hype, setting up a new TypeScript (x React) library can b
   - [`npm run build` or `yarn build`](#npm-run-build-or-yarn-build)
   - [`npm test` or `yarn test`](#npm-test-or-yarn-test)
   - [`npm run lint` or `yarn lint`](#npm-run-lint-or-yarn-lint)
+  - [`prepare` script](#prepare-script)
 - [Optimizations](#optimizations)
   - [Development-only Expressions + Treeshaking](#development-only-expressions--treeshaking)
     - [Rollup Treeshaking](#rollup-treeshaking)
@@ -88,6 +89,11 @@ By default, runs tests related to files changed since the last commit.
 
 Runs Eslint with Prettier on .ts and .tsx files.
 If you want to customize eslint you can add an `eslint` block to your package.json, or you can run `yarn lint --write-file` and edit the generated `.eslintrc.js` file.
+
+### `prepare` script
+
+Bundles and packages to the `dist` folder.
+Runs automatically when you run either `npm publish` or `yarn publish`. The `prepare` script will run the equivalent of `npm run build` or `yarn build`. It will also be run if your module is installed as a git dependency (ie: `"mymodule": "github:myuser/mymodule#some-branch"`) so it can be depended on without checking the transpiled code into git.
 
 ## Optimizations
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "prepare": "tsc -p tsconfig.json",
     "build": "tsc -p tsconfig.json",
-    "lint": "yarn build && yarn lint:post-build",
+    "lint": "yon build && yon lint:post-build",
     "lint:post-build": "node dist/index.js lint src test --ignore-pattern 'test/tests/lint'",
     "test": "jest --config ./test/jest.config.json"
   },
@@ -112,11 +112,12 @@
     "husky": "^3.0.9",
     "pretty-quick": "^2.0.0",
     "ps-tree": "^1.2.0",
-    "react": "^16.8.6"
+    "react": "^16.8.6",
+    "yarn-or-npm": "^3.0.1"
   },
   "husky": {
     "hooks": {
-      "pre-commit": "pretty-quick --staged --pattern '!test/tests/lint/**' && yarn lint"
+      "pre-commit": "pretty-quick --staged --pattern '!test/tests/lint/**' && yon lint"
     }
   },
   "prettier": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "prepare": "tsc -p tsconfig.json",
     "build": "tsc -p tsconfig.json",
-    "lint": "yon build && yon lint:post-build",
+    "lint": "yarn build && yarn lint:post-build",
     "lint:post-build": "node dist/index.js lint src test --ignore-pattern 'test/tests/lint'",
     "test": "jest --config ./test/jest.config.json"
   },
@@ -112,12 +112,11 @@
     "husky": "^3.0.9",
     "pretty-quick": "^2.0.0",
     "ps-tree": "^1.2.0",
-    "react": "^16.8.6",
-    "yarn-or-npm": "^3.0.1"
+    "react": "^16.8.6"
   },
   "husky": {
     "hooks": {
-      "pre-commit": "pretty-quick --staged --pattern '!test/tests/lint/**' && yon lint"
+      "pre-commit": "pretty-quick --staged --pattern '!test/tests/lint/**' && yarn lint"
     }
   },
   "prettier": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -288,6 +288,7 @@ prog
               ? 'tsdx test --env=jsdom --passWithNoTests'
               : 'tsdx test',
           lint: 'tsdx lint',
+          prepare: 'tsdx build',
         },
         peerDependencies: template === 'react' ? { react: '>=16' } : {},
         husky: {


### PR DESCRIPTION
The prepare script runs before publishing to npm and when the module is installed as a git dependency. 