### PR TITLE
feat: --noClean option for build

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -416,6 +416,8 @@ prog
   .example('build --name Foo')
   .option('--format', 'Specify module format(s)', 'cjs,esm')
   .example('build --format cjs,esm')
+  .option('--noClean', "Don't clean the dist folder")
+  .example('build --noClean')
   .option('--tsconfig', 'Specify custom tsconfig path')
   .example('build --tsconfig ./tsconfig.foo.json')
   .option(
@@ -428,7 +430,9 @@ prog
   .action(async (dirtyOpts: any) => {
     const opts = await normalizeOpts(dirtyOpts);
     const buildConfigs = createBuildConfigs(opts);
-    await cleanDistFolder();
+    if (!opts.noClean) {
+      await cleanDistFolder();
+    }
     await ensureDistFolder();
     const logger = await createProgressEstimator();
     if (opts.format.includes('cjs')) {


### PR DESCRIPTION
I want to build multi file for my library, unfortunately tsdx will clean previous build assets, which makes it's hard to implement, It will be conveniently to let user decide whether to clean dist file
![image](https://user-images.githubusercontent.com/8898718/68927605-1aed5500-07c3-11ea-84b8-583c0858866d.png)
