### PR TITLE
Fix error when adding `@babel/preset-env` without options

### DIFF
--- a/src/babelPluginTsdx.ts
+++ b/src/babelPluginTsdx.ts
@@ -120,7 +120,7 @@ export const babelPluginTsdx = babelPlugin.custom((babelCore: any) => ({
               modules: false,
               exclude: merge(
                 ['transform-async-to-generator', 'transform-regenerator'],
-                preset.options.exclude || []
+                (preset.options && preset.options.exclude) || []
               ),
             }
           ),


### PR DESCRIPTION
Adding `@babel/preset-env` without options to `.babelrc` will cause an error

`.babelrc`
```json
{
  "presets": ["@babel/preset-env"]
}
```

**Error**
```
✖ Failed to compile
(babel plugin) TypeError: Cannot read property 'exclude' of undefined
TypeError: Cannot read property 'exclude' of undefined
    at Object.config (/Users/jirat.ki/Code/lab/tsdxLib/node_modules/tsdx/dist/babelPluginTsdx.js:98:127)
    at Object.transform (/Users/jirat.ki/Code/lab/tsdxLib/node_modules/rollup-plugin-babel/dist/rollup-plugin-babel.cjs.js:197:26)
    at /Users/jirat.ki/Code/lab/tsdxLib/node_modules/rollup/dist/rollup.js:12084:25
```
