### PR TITLE
Remove unnecessary yarn install command in GH action

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -20,9 +20,6 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
-      - name: Install yarn package manager
-        run: npm install -g yarn
-
       - name: Install deps and build
         run: yarn install --frozen-lockfile
 


### PR DESCRIPTION
this command is breaking the windows build for our CI and causing a lot of greenkeeper false positives. and based on [this](https://github.com/actions/setup-node/commit/57adacb752d56f434eed924bad6ef995a163861b) doesnt seem to be necessary

making this a PR in case this works for github