### PR TITLE
fix(chore): fixed minor typo

### DIFF
--- a/src/errors/extractErrors.ts
+++ b/src/errors/extractErrors.ts
@@ -42,7 +42,7 @@ export async function extractErrors(opts: any) {
   const errorMapFilePath = opts.errorMapFilePath;
   let existingErrorMap: any;
   try {
-    // Using `fs.readFileSync` instead of `require` here, because `require()`
+    // Using `fs.readFile` instead of `require` here, because `require()`
     // calls are cached, and the cache map is not properly invalidated after
     // file changes.
     existingErrorMap = JSON.parse(await fs.readFile(errorMapFilePath, 'utf8'));


### PR DESCRIPTION
#291 replaced all instances of `sync` versions of some methods with their corresponding `async` versions. Updated the comment accordingly.