### PR TITLE
(types/fix): explicit Rollup typing, fix treeshake location

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,7 @@ try {
 
 // check for custom tsdx.config.js
 let tsdxConfig = {
-  rollup(config: any, _options: any) {
+  rollup(config: RollupOptions, _options: TsdxOptions): RollupOptions {
     return config;
   },
 };


### PR DESCRIPTION
- treeshake was in output, but it's not a config of output :/ :/ :/
  - once explicit types were added, this was a big red underline :/ :/

Yeaaaaaaaaa so that's kind of a problem 😕 😕 😕 Related to #365 and potentially related to #171. This bug has been around for a long enough time that it's fix may cause some breakage, idk.

Related: Does the `eslint` config error on getters and setters? That wouldn't help with imported code, but would at least reduce unexpected errors in one's own codebase.

Also should we add some regression tests for treeshaking? It's typed correctly _now_, but might make sense to have a test for something like this that could be considered critical and hard to catch, idk.

<hr>

I was going around adding types to builder code during #367 because type-checking would add a lot more confidence and discovered this along the way -- figured it should be extracted out as its own commit.