### PR TITLE
(fix/format): formatting of #366 didn't pass lint

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -577,9 +577,9 @@ prog
         ...jestConfig,
       })
     );
- 
+
     if (!process.env.CI) {
-      argv.push('--watch') // run jest in watch mode unless in CI
+      argv.push('--watch'); // run jest in watch mode unless in CI
     }
 
     const [, ...argsToPassToJestCli] = argv;


### PR DESCRIPTION
It doesn't seem like GH Actions / CI are running for each PR, as no status checks appear for them --    probably why #366 slipped through. I'm not sure why they're not running, looks normal to me though I've never used GH Actions before for CI.