### PR TITLE
(fix/ci): GitHub Actions should run on PRs as well

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,6 +1,6 @@
 name: Node CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   test:


### PR DESCRIPTION
- previously would only run on branches from origin, so PRs from a
  fork would not trigger them

Follow up to #372 once I took a look at the GH Actions docs. @sw-yx GH Actions were probably working for your use case because you were using branches on this repo and not from a fork during your PRs. The Actions are running in this PR from my fork now.

Now _oddly enough_, #366 did run the Actions (being an origin branch), and [_somehow they passed???_](https://github.com/jaredpalmer/tsdx/pull/366/checks?check_run_id=343558866). I have no idea why the lint test didn't fail 😳 

Also as a follow-up to this -- you probably want to add branch protection rules for `master` so the checks are required before passing. This would also make it easier to detect when there's a CI logic bug.