### PR TITLE
(fix): added rollup plugin @zerollup/ts-transform-paths, injected as …

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
-  "name": "tsdx",
+  "name": "@ambroseus/tsdx",
+  "publishConfig": {
+    "access": "public"
+  },
   "version": "0.11.0",
   "author": "Jared Palmer <jared@palmer.net>",
   "description": "Zero-config TypeScript package development",
@@ -48,6 +51,7 @@
     "@types/shelljs": "^0.8.5",
     "@typescript-eslint/eslint-plugin": "^2.12.0",
     "@typescript-eslint/parser": "^2.12.0",
+    "@zerollup/ts-transform-paths": "^1.7.8",
     "ansi-escapes": "^4.2.1",
     "asyncro": "^3.0.0",
     "babel-eslint": "^10.0.3",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,5 @@
 {
-  "name": "@ambroseus/tsdx",
-  "publishConfig": {
-    "access": "public"
-  },
+  "name": "tsdx",
   "version": "0.11.0",
   "author": "Jared Palmer <jared@palmer.net>",
   "description": "Zero-config TypeScript package development",

--- a/src/createRollupConfig.ts
+++ b/src/createRollupConfig.ts
@@ -14,6 +14,7 @@ import replace from '@rollup/plugin-replace';
 import resolve from 'rollup-plugin-node-resolve';
 import sourceMaps from 'rollup-plugin-sourcemaps';
 import typescript from 'rollup-plugin-typescript2';
+import transformPaths from '@zerollup/ts-transform-paths';
 import { extractErrors } from './errors/extractErrors';
 import { babelPluginTsdx } from './babelPluginTsdx';
 import { TsdxOptions } from './types';
@@ -49,6 +50,9 @@ export async function createRollupConfig(opts: TsdxOptions) {
   try {
     tsconfigJSON = fs.readJSONSync(resolveApp('tsconfig.json'));
   } catch (e) {}
+
+  const pathTransformer = (service: any): any =>
+    transformPaths(service.getProgram());
 
   return {
     // Tell Rollup the entry point to the package
@@ -153,6 +157,7 @@ export async function createRollupConfig(opts: TsdxOptions) {
             target: 'esnext',
           },
         },
+        transformers: [pathTransformer],
       }),
       babelPluginTsdx({
         exclude: 'node_modules/**',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1169,6 +1169,20 @@
     semver "^6.3.0"
     tsutils "^3.17.1"
 
+"@zerollup/ts-helpers@^1.7.4":
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/@zerollup/ts-helpers/-/ts-helpers-1.7.4.tgz#59ac8c643b8cc6def5449691630091226991da36"
+  integrity sha512-8JLREeiO6MtmJhU8kw/eNwi+HKlh/K3cMlpH6HVbW53bqhAgTvt8KnIqFh9FMNbCL3QDht35g8VJHVWYkMEt2A==
+  dependencies:
+    resolve "^1.12.0"
+
+"@zerollup/ts-transform-paths@^1.7.8":
+  version "1.7.8"
+  resolved "https://registry.yarnpkg.com/@zerollup/ts-transform-paths/-/ts-transform-paths-1.7.8.tgz#e9de4ed23e9b6f584b9a625141326456f71d0a8a"
+  integrity sha512-xh6KZRF3cD/pYeQypADTh7U9zAU8vgG7PvUT9m20mW8rsiUF69OKDM+9CsR483ceXVh5PC5AHUA/GAvsJ1iVbw==
+  dependencies:
+    "@zerollup/ts-helpers" "^1.7.4"
+
 abab@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.2.tgz#a2fba1b122c69a85caa02d10f9270c7219709a9d"


### PR DESCRIPTION
…transformer in rollup-plugin-typescript2 config

closes https://github.com/jaredpalmer/tsdx/issues/336

---

_Edit/Summary From @jaredpalmer:_

When using tsdx with larger packages, it is useful to use typescript path aliasing to avoid relative imports. This change allows tsdx (rollup and typescript) to respect such options.

**Before**
```
import Button from 'components/Button'
// becomes
const Button = require('components/button') // omitting interop stuff
```

**After**

```
import Button from 'components/Button'
// becomes
const Button = require('./components/button') // omitting interop stuff
```