### PR TITLE
(clean): remove .rts_cache_* from storybook gitignore

### DIFF
--- a/templates/react-with-storybook/gitignore
+++ b/templates/react-with-storybook/gitignore
@@ -2,8 +2,4 @@
 .DS_Store
 node_modules
 .cache
-.rts2_cache_cjs
-.rts2_cache_esm
-.rts2_cache_umd
-.rts2_cache_system
 dist


### PR DESCRIPTION
- these are no longer necessary after my cacheRoot changes

#318 copied the gitignore from the other examples at the time, but my PR at #329 was merged earlier, which means those directories no longer exist