### PR TITLE
(ci): add a lint job so PRs will require passing lint

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -3,6 +3,24 @@ name: Node CI
 on: [push, pull_request]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    name: Lint on node 10.x and ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Use Node.js 10.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 10.x
+
+      - name: Install deps and build
+        run: yarn install --frozen-lockfile
+
+      - name: Lint codebase
+        run: yarn lint
+
   test:
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
- a few recent PRs got in without passing lint, this breaks all future
  PRs/branches/commits because pre-commit will fail when it runs lint

Turns out `lint` was never running in CI! Which explains why #370 and #366 passed (and my confusion in #373 )
This should make formatting fixes like #372 and #377 unnecessary in the future if only PRs that pass lint are merged.

I limited this to run on Node v10 and `ubuntu-latest` -- not sure if a matrix is necessary for self-linting. The existing test suite already has tests for `tsdx lint` and that runs over the matrix ofc.