### PR TITLE
(docs): improve test watch mode docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,11 +450,16 @@ Examples
 
 This runs Jest v24.x in watch mode. See [https://jestjs.io](https://jestjs.io) for options. If you are using the React template, jest uses the flag `--env=jsdom` by default.
 
-If you would like to disable watch mode, this is one way to do it in your `package.json`:
+If you would like to disable watch mode, you can set the environment variable `CI=true`. For instance, you could set up your `package.json` `scripts` like:
 
-```
-"test": "CI=true tsdx test --color"
-"test:coverage": "CI=true tsdx test --color --coverage"
+```json
+{
+  "scripts": {
+    "test": "CI=true tsdx test",
+    "test:watch": "tsdx test",
+    "test:coverage": "CI=true tsdx test --coverage"
+  }
+}
 ```
 
 ### `tsdx lint`


### PR DESCRIPTION
- it was not clearly stated that CI=true was what needed to be added,
  so explicitly state that
- similarly, --color was an unnecessary option to pass and may have
  caused confusion, potentially making users believe that it was
  necessary in order to disable watch mode
  - also, --color does not seem to be a valid option of Jest, but
    [--colors](https://jestjs.io/docs/en/cli#--colors) (note the s) is used to force highlighting in non-TTY

- also, properly format package.json example as JSON, including the
  "scripts" section
- and add a test:watch script for context, making more explicit the
  difference between non-watch and watch mode

Follow-up to #385 , related to #319, #366 . Though this documentation does make me wonder whether it makes sense to have `--watch` as a default. It's much more intuitive to pass `--watch` than to prefix with `CI=true`