### PR TITLE
(clean): remove --env=jsdom as JSDOM is Jest's default

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,7 +448,7 @@ Examples
 
 ### `tsdx test`
 
-This runs Jest v24.x in watch mode. See [https://jestjs.io](https://jestjs.io) for options. If you are using the React template, jest uses the flag `--env=jsdom` by default.
+This runs Jest v24.x in watch mode. See [https://jestjs.io](https://jestjs.io) for options.
 
 If you would like to disable watch mode, this is one way to do it in your `package.json`:
 

--- a/src/templates/react.ts
+++ b/src/templates/react.ts
@@ -19,7 +19,7 @@ const reactTemplate: Template = {
     },
     scripts: {
       ...basicTemplate.packageJson.scripts,
-      test: 'tsdx test --env=jsdom --passWithNoTests',
+      test: 'tsdx test --passWithNoTests',
     } as PackageJson['scripts'],
   },
 };


### PR DESCRIPTION
- the React template and docs for it had --env=jsdom explicitly set,
  but there's no need to do this, as [Jest uses JSDOM by default](https://jestjs.io/docs/en/configuration#testenvironment-string) already

- setting it a second time in CLI also [overrides any custom configs](https://jestjs.io/docs/en/cli#options)

Docs seemed to be introduced in 4296413d8af48efbfccae4814178294fba847673 and template in #68 . This seems to have matched the templating of CRA v1, but this [was changed in CRA v2](https://github.com/facebook/create-react-app/blob/master/CHANGELOG-2.x.md#the-default-jest-environment-was-changed-to-jsdom). I'm guessing CRA may have defaulted to `node` under-the-hood in v1 but I'm not really sure (did not investigate history any further). `tsdx` seemed to never default to `node`, so seems like it was always redundant in `tsdx`.

There's a separate question of whether to use `node` test environment in the default template, but a non-React library may still be a browser-based library, and therefore might still want to use `jsdom`.
I think using `node` is an optimization/option that should be left to the user; setting it to `node` by default would probably cause more confusion than optimization (and it may not shave off much time, if any, based on my experience at least).