### PR TITLE
(docs): add warning to tsdx.config.js usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,9 @@ _TODO: Simple guide to host error codes to be completed_
 
 ### Rollup
 
+> **❗⚠️❗ Warning**: <br>
+> These modifications will override the default behavior and configuration of TSDX. As such they can invalidate internal guarantees and assumptions. These types of changes can break internal behavior and can be very fragile against updates. Use with discretion!
+
 TSDX uses Rollup under the hood. The defaults are solid for most packages (Formik uses the defaults!). However, if you do wish to alter the rollup configuration, you can do so by creating a file called `tsdx.config.js` at the root of your project like so:
 
 ```js


### PR DESCRIPTION
- similar to the ones that exist in [react-app-rewired](https://github.com/timarney/react-app-rewired/#rewire-your-app-) and [customize-cra](https://github.com/arackaf/customize-cra#-warning)
  as, like CRA, changing TSDX internals is a fragile path

Related to https://github.com/jaredpalmer/tsdx/issues/389#issuecomment-568866380 , #379 . This escape hatch is being used quite a bit by TSDX users as seen in various issues, but I'm not sure if all are aware of the risks that inherently entails (as I detailed in https://github.com/jaredpalmer/tsdx/issues/389#issuecomment-568866380). Those risks should be more explicit, as this may catch users off-guard, especially during updates, as even a patch update could break usage inside `tsdx.config.js`.

Plugins could at least pin a peer dependency and update when their own tests pass for newer versions, but ad-hoc code is more brittle than that. Notably, [Razzle does support plugins](https://github.com/jaredpalmer/razzle#plugins), and those are listed as the first option before modifying `webpack` config directly (`rollup` for TSDX)

Probably makes sense to leave this to @jaredpalmer as [Razzle doesn't quite have the same language](https://github.com/jaredpalmer/razzle#extending-webpack).