### PR TITLE
(refactor): use path constants instead of custom resolveApp

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,6 +2,7 @@ import { resolveApp } from './utils';
 
 export const paths = {
   appPackageJson: resolveApp('package.json'),
+  tsconfigJson: resolveApp('tsconfig.json'),
   testsSetup: resolveApp('test/setupTests.ts'),
   appRoot: resolveApp('.'),
   appSrc: resolveApp('src'),

--- a/src/createRollupConfig.ts
+++ b/src/createRollupConfig.ts
@@ -1,9 +1,4 @@
-import {
-  safeVariableName,
-  safePackageName,
-  external,
-  resolveApp,
-} from './utils';
+import { safeVariableName, safePackageName, external } from './utils';
 import { paths } from './constants';
 import { RollupOptions } from 'rollup';
 import { terser } from 'rollup-plugin-terser';
@@ -50,7 +45,7 @@ export async function createRollupConfig(
 
   let tsconfigJSON;
   try {
-    tsconfigJSON = fs.readJSONSync(resolveApp('tsconfig.json'));
+    tsconfigJSON = await fs.readJSON(paths.tsconfigJson);
   } catch (e) {}
 
   return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,7 @@ const prog = sade('tsdx');
 let appPackageJson: PackageJson;
 
 try {
-  appPackageJson = fs.readJSONSync(resolveApp('package.json'));
+  appPackageJson = fs.readJSONSync(paths.appPackageJson);
 } catch (e) {}
 
 // check for custom tsdx.config.js
@@ -464,7 +464,7 @@ prog
     const logger = await createProgressEstimator();
     if (opts.format.includes('cjs')) {
       try {
-        await util.promisify(mkdirp)(resolveApp('./dist'));
+        await ensureDistFolder();
         const promise = writeCjsEntryFile(opts.name).catch(logError);
         logger(promise, 'Creating entry file');
       } catch (e) {


### PR DESCRIPTION
- and use ensureDistFolder since that exists now
- and use async readJSON since most were converted before

Merges stuff from #130, #327 , #291 , #142 as they were all merged together at different times but changed some conventions in the codebase or DRY'd things up.