### PR TITLE
(CI fix) Attempt to fix persistent Windows error

### DIFF
--- a/test/fixtures/util.js
+++ b/test/fixtures/util.js
@@ -1,17 +1,13 @@
-
-
 const shell = require('shelljs');
 const path = require('path');
 const rootDir = process.cwd();
+shell.chmod(755, rootDir); // ensure correct perms
 
 shell.config.silent = true;
 
 module.exports = {
   setupStageWithFixture: (stageName, fixtureName) => {
     const stagePath = path.join(rootDir, stageName);
-    shell.chmod(755, rootDir);
-    shell.ls(rootDir);
-    shell.ls(stagePath);
     shell.mkdir(stagePath);
     shell.exec(`cp -a ${rootDir}/test/fixtures/${fixtureName}/. ${stagePath}/`);
     shell.ln(

--- a/test/fixtures/util.js
+++ b/test/fixtures/util.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 const shell = require('shelljs');
 const path = require('path');
@@ -9,6 +9,9 @@ shell.config.silent = true;
 module.exports = {
   setupStageWithFixture: (stageName, fixtureName) => {
     const stagePath = path.join(rootDir, stageName);
+    shell.chmod(755, rootDir);
+    shell.ls(rootDir);
+    shell.ls(stagePath);
     shell.mkdir(stagePath);
     shell.exec(`cp -a ${rootDir}/test/fixtures/${fixtureName}/. ${stagePath}/`);
     shell.ln(


### PR DESCRIPTION
we're getting this error in CI

```bash
FAIL test/tests/tsdx-build.test.js (28.254s)
  ● tsdx build › should create the library correctly

    ShellJSInternalError: EPERM: operation not permitted, mkdir 'D:/a/tsdx/tsdx/stage-build'

      10 |   setupStageWithFixture: (stageName, fixtureName) => {
      11 |     const stagePath = path.join(rootDir, stageName);
    > 12 |     shell.mkdir(stagePath);
         |           ^
      13 |     shell.exec(`cp -a ${rootDir}/test/fixtures/${fixtureName}/. ${stagePath}/`);
      14 |     shell.ln(
      15 |       '-s',

      at ../node_modules/shelljs/src/mkdir.js:83:12
          at Array.forEach (<anonymous>)
      at Object._mkdir (../node_modules/shelljs/src/mkdir.js:59:8)
      at Object.mkdir (../node_modules/shelljs/src/common.js:384:25)
      at Object.setupStageWithFixture (fixtures/util.js:12:11)
      at Object.<anonymous> (tests/tsdx-build.test.js:37:10)

  ● tsdx build › should clean the dist directory before rebuilding

```
