### PR TITLE
(optim/test): use node testEnvironment

### DIFF
--- a/test/jest.config.json
+++ b/test/jest.config.json
@@ -1,4 +1,5 @@
 {
+  "testEnvironment": "node",
   "roots": ["<rootDir>/tests"],
   "collectCoverageFrom": ["**/*.js"],
   "transform": {


### PR DESCRIPTION
- default is jsdom, which we don't need

- also fix missing newline at EOF

Wrote this a while ago, but decided not to PR earlier as it didn't speed up tests _at all_ locally o.o Figured I should PR it now as it's related to #396 , can decide whether to close or merge now.

I guess this is still good to have for _correctness_ of tests, even if doesn't actually optimize anything. It might optimize windows tests on CI, as those seem to be slower than the rest but 🤷‍♂ 

<hr>

Also think this will be the last of my PRs for the day, was really on a roll today getting in lots of changes I had in-progress 😅 (though most of them were small)