### PR TITLE
(fix): revert #130's breaking change of tsconfig options

### DIFF
--- a/src/createRollupConfig.ts
+++ b/src/createRollupConfig.ts
@@ -144,7 +144,12 @@ export async function createRollupConfig(
             sourceMap: true,
             declaration: true,
             jsx: 'react',
-            target: 'es5',
+          },
+        },
+        tsconfigOverride: {
+          compilerOptions: {
+            // TS -> esnext, then leave the rest to babel-preset-env
+            target: 'esnext',
           },
         },
         check: opts.transpileOnly === false,


### PR DESCRIPTION
- not sure why this change was made in that PR as it was unrelated to
  the rest, but it broke some things related to Babel usage and maybe
  other things
  - e.g. babel macros were not included per #413
  - and it used `tslib` instead of adding babel helper functions

- add a comment of why it seems like the target is overridden to esnext
  - though I am not sure of the original reasoning, as it has existed
    since very early versions of TSDX, see #130 comments

Fixes #413 

Whether TS should transpile to target or Babel should is a good question to raise, but for now this just reverts the breaking change.
Should probably document in the README that `tsconfig` target is ignored and that users should use Babel's `preset-env` to configure the target instead.
Should also probably add more tests around this as bugs / breaking changes like this in TSDX's build output can have ripple-effects on libraries using it (vs. the other commands don't affect output, so the impact is limited to just library authors as opposed to library users).