### PR TITLE
[Docs]: Added a reference to contributing guidelines as part of the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,6 +490,10 @@ Examples
   $ tsdx lint src --report-file report.json
 ```
 
+## Contributing
+
+Please see the [Contributing Guidelines](./CONTRIBUTING.md).
+
 ## Author
 
 - [Jared Palmer](https://twitter.com/jaredpalmer)


### PR DESCRIPTION
It is a good idea to have a reference to the `contributing guidelines` as part of the docs which the users may miss out if otherwise.