### PR TITLE
Revert "default jest watch unless in CI" PR #366

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,16 +452,14 @@ Examples
 
 ### `tsdx test`
 
-This runs Jest v24.x in watch mode. See [https://jestjs.io](https://jestjs.io) for options.
-
-If you would like to disable watch mode, you can set the environment variable `CI=true`. For instance, you could set up your `package.json` `scripts` like:
+This runs Jest v24.x. See [https://jestjs.io](https://jestjs.io) for options. For example, if you would like to run in watch mode, you can run `tsdx test --watch`. So you could set up your `package.json` `scripts` like:
 
 ```json
 {
   "scripts": {
-    "test": "CI=true tsdx test",
-    "test:watch": "tsdx test",
-    "test:coverage": "CI=true tsdx test --coverage"
+    "test": "tsdx test",
+    "test:watch": "tsdx test --watch",
+    "test:coverage": "tsdx test --coverage"
   }
 }
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -529,10 +529,6 @@ prog
       })
     );
 
-    if (!process.env.CI) {
-      argv.push('--watch'); // run jest in watch mode unless in CI
-    }
-
     const [, ...argsToPassToJestCli] = argv;
     jest.run(argsToPassToJestCli);
   });


### PR DESCRIPTION
Revert "default jest watch unless in CI" PR #366

we decided to revert this behavior in https://github.com/jaredpalmer/tsdx/issues/408

closes https://github.com/jaredpalmer/tsdx/issues/408