### PR TITLE
Deprecate Node 8 support

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -26,7 +26,7 @@ jobs:
 
     strategy:
       matrix:
-        node: ['8.12.x', '10.x', '12.x']
+        node: ['10.x', '12.x', '13.x']
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     name: Test on node ${{ matrix.node }} and ${{ matrix.os }}


### PR DESCRIPTION
closes https://github.com/jaredpalmer/tsdx/issues/424#issuecomment-573202098

also begins Node 13 in preparation for for Node 14 release in April (goes LTS in Oct this year)

recheck https://github.com/jaredpalmer/tsdx/pull/422 once merged