### PR TITLE
(fix) Enforce Node version for tsdx create, update documentation to express requirement.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ cd mylib
 yarn start
 ```
 
+_Requires Node `>= 10`._
+
+
 That's it. You don't need to worry about setting up Typescript or Rollup or Jest or other plumbing. Just start editing `src/index.ts` and go!
 
 Below is a list of commands you will probably find useful:

--- a/package.json
+++ b/package.json
@@ -116,11 +116,13 @@
     "@types/react": "^16.9.11",
     "@types/rollup-plugin-json": "^3.0.2",
     "@types/rollup-plugin-sourcemaps": "^0.4.2",
+    "@types/semver": "^6.2.0",
     "doctoc": "^1.4.0",
     "husky": "^3.0.9",
     "pretty-quick": "^2.0.0",
     "ps-tree": "^1.2.0",
-    "react": "^16.8.6"
+    "react": "^16.8.6",
+    "semver": "^7.1.1"
   },
   "husky": {
     "hooks": {

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -89,3 +89,9 @@ export const start = async function(projectName: string) {
   ${chalk.green('https://github.com/jaredpalmer/tsdx/issues')}
 `;
 };
+
+export const incorrectNodeVersion = function(requiredVersion: string) {
+  return `Unsupported Node version! Your current Node version (${chalk.red(
+    process.version
+  )}) does not satisfy the requirement of Node ${chalk.cyan(requiredVersion)}.`;
+};

--- a/src/templates/basic.ts
+++ b/src/templates/basic.ts
@@ -12,6 +12,9 @@ const basicTemplate: Template = {
     // module: `dist/${safeName}.esm.js`,
     typings: `dist/index.d.ts`,
     files: ['dist'],
+    engines: {
+      node: '>=10',
+    },
     scripts: {
       start: 'tsdx watch',
       build: 'tsdx build',

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,4 +56,7 @@ export interface PackageJson {
   eslint?: any;
   dependencies?: { [packageName: string]: string };
   devDependencies?: { [packageName: string]: string };
+  engines?: {
+    node?: string;
+  };
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -46,3 +46,7 @@ export function getReactVersion({
     (devDependencies && devDependencies.react)
   );
 }
+
+export function getNodeEngineRequirement({ engines }: PackageJson) {
+  return engines && engines.node;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1179,6 +1179,11 @@
     "@types/node" "*"
     rollup "^0.63.4"
 
+"@types/semver@^6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-6.2.0.tgz#d688d574400d96c5b0114968705366f431831e1a"
+  integrity sha512-1OzrNb4RuAzIT7wHSsgZRlMBlNsJl+do6UblR7JMW4oB7bbR+uBEYtUh7gEc/jM84GGilh68lSOokyM/zNUlBA==
+
 "@types/shelljs@^0.8.5":
   version "0.8.6"
   resolved "https://registry.yarnpkg.com/@types/shelljs/-/shelljs-0.8.6.tgz#45193a51df99e0f00513c39a2152832399783221"
@@ -5801,6 +5806,11 @@ semver@^6.0.0, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+semver@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.1.1.tgz#29104598a197d6cbe4733eeecbe968f7b43a9667"
+  integrity sha512-WfuG+fl6eh3eZ2qAf6goB7nhiCd7NPXhmyFxigB/TOkQyeLP8w8GsVehvtGNtnNmyboz4TgeK40B1Kbql/8c5A==
 
 serialize-javascript@^1.7.0:
   version "1.9.1"


### PR DESCRIPTION
Fixes https://github.com/jaredpalmer/tsdx/issues/432

There was a few ways I could have approached this, so let me know if there's something more ideal.

To test:
1. Build. 
2. Change Node version to < 10 - `nvm use 8.11.3`
3. Run `node /dist/index.js create foo`, select any template – observe error
```
Unsupported Node version! Your current Node version (v8.11.3) does not satisfy the requirement of Node >=10.
```
4. Change Node version to >=10 - `nvm use 10.17.0`
5. Run `node /dist/index.js create bar`, select any template – observe success.