### PR TITLE
Respect custom tsconfig path for esModuleInterop

### DIFF
--- a/src/createRollupConfig.ts
+++ b/src/createRollupConfig.ts
@@ -45,7 +45,7 @@ export async function createRollupConfig(
 
   let tsconfigJSON;
   try {
-    tsconfigJSON = await fs.readJSON(paths.tsconfigJson);
+    tsconfigJSON = await fs.readJSON(opts.tsconfig || paths.tsconfigJson);
   } catch (e) {}
 
   return {


### PR DESCRIPTION
When custom `tsconfig` is used (e.g. `tsdx build --tsconfig tsconfig.build.json`), it is ignored in `createRollupConfig`.

For example, this causes bug in reach-ui build https://github.com/reach/reach-ui/issues/434. They use `tsconfig.build.json`, which is being ignore and the build files are missing `Object.defineProperty(exports, '__esModule', { value: true });`. 