### PR TITLE
(remove): redundant/confusing tsconfig target in templates

### DIFF
--- a/templates/basic/tsconfig.json
+++ b/templates/basic/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "include": ["src", "types", "test"],
   "compilerOptions": {
-    "target": "es5",
     "module": "esnext",
     "lib": ["dom", "esnext"],
     "importHelpers": true,

--- a/templates/react-with-storybook/tsconfig.json
+++ b/templates/react-with-storybook/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "include": ["src", "types", "test"],
   "compilerOptions": {
-    "target": "es5",
     "module": "esnext",
     "lib": ["dom", "esnext"],
     "importHelpers": true,

--- a/templates/react/tsconfig.json
+++ b/templates/react/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "include": ["src", "types", "test"],
   "compilerOptions": {
-    "target": "es5",
     "module": "esnext",
     "lib": ["dom", "esnext"],
     "importHelpers": true,

--- a/test/fixtures/build-default/tsconfig.json
+++ b/test/fixtures/build-default/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "target": "es5",
     "module": "ESNext",
     "lib": ["dom", "esnext"],
     "declaration": true,

--- a/test/fixtures/build-invalid/tsconfig.json
+++ b/test/fixtures/build-invalid/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "target": "es5",
     "module": "ESNext",
     "lib": ["dom", "esnext"],
     "declaration": true,

--- a/test/fixtures/build-withConfig/tsconfig.json
+++ b/test/fixtures/build-withConfig/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "target": "es5",
     "module": "ESNext",
     "lib": ["dom", "esnext"],
     "declaration": true,


### PR DESCRIPTION
- tsconfig target is always overwritten to ESNext by TSDX, and then
  the rest of the transpilation is done by @babel/preset-env
  - having templates with target set gives the false impression that
    target can be freely configured

- also remove from tests as it's unused there

See #415 for more about why the target is overwritten by TSDX