### PR TITLE
(fix): ensure Babel presets are merged

### DIFF
--- a/src/babelPluginTsdx.ts
+++ b/src/babelPluginTsdx.ts
@@ -104,11 +104,13 @@ export const babelPluginTsdx = babelPlugin.custom((babelCore: any) => ({
     );
 
     const babelOptions = config.options || {};
+    babelOptions.presets = babelOptions.presets || [];
 
-    const envIdx = (babelOptions.presets || []).findIndex((preset: any) =>
+    const envIdx = babelOptions.presets.findIndex((preset: any) =>
       preset.file.request.includes('@babel/preset-env')
     );
 
+    // if they use preset-env, merge their options with ours
     if (envIdx !== -1) {
       const preset = babelOptions.presets[envIdx];
       babelOptions.presets[envIdx] = createConfigItem(
@@ -134,7 +136,8 @@ export const babelPluginTsdx = babelPlugin.custom((babelCore: any) => ({
         }
       );
     } else {
-      babelOptions.presets = createConfigItems('preset', [
+      // if no preset-env, add it & merge with their presets
+      const defaultPresets = createConfigItems('preset', [
         {
           name: '@babel/preset-env',
           targets: customOptions.targets,
@@ -143,6 +146,12 @@ export const babelPluginTsdx = babelPlugin.custom((babelCore: any) => ({
           exclude: ['transform-async-to-generator', 'transform-regenerator'],
         },
       ]);
+
+      babelOptions.presets = mergeConfigItems(
+        'preset',
+        defaultPresets,
+        babelOptions.presets
+      );
     }
 
     // Merge babelrc & our plugins together


### PR DESCRIPTION
- previously, if preset-env were not found in the user's presets,
  their presets would be overwritten by a single preset-env entry
  - now it properly merges their presets with an entry for preset-env

Fixes #443 

I _think_ this is good, but still need to create a test set-up for custom Babel configs. This requires installing some dependencies for automated tests. The `withConfig` `tsdx.config.js` fixture also requires installing some deps for automated tests and is currently a manual test (which means it isn't tested frequently -- I haven't tested it once in all my PRs), so would like to get that to be auto too.