### PR TITLE
(fix): check for JSX extension for entry files

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -75,6 +75,8 @@ async function jsOrTs(filename: string) {
     ? '.ts'
     : (await isFile(resolveApp(filename + '.tsx')))
     ? '.tsx'
+    : (await isFile(resolveApp(filename + '.jsx')))
+    ? '.jsx'
     : '.js';
 
   return resolveApp(`${filename}${extension}`);


### PR DESCRIPTION
- previously, TS, TSX, and JS were checked, but not JSX

Fixes #143 . Credits to @sisp for finding this and providing the suggested solution there. A PR hadn't ever been made and that issue's a bit old; this is related to #473 and #443 so figured it should be done sooner rather than later.