### PR TITLE
(types): enforce stricter typings

### DIFF
--- a/src/babelPluginTsdx.ts
+++ b/src/babelPluginTsdx.ts
@@ -47,7 +47,7 @@ export const createConfigItems = (type: any, items: any[]) => {
   });
 };
 
-export const babelPluginTsdx = babelPlugin.custom((babelCore: any) => ({
+export const babelPluginTsdx = babelPlugin.custom(() => ({
   // Passed the plugin options.
   options({ custom: customOptions, ...pluginOptions }: any) {
     return {

--- a/src/createEslintConfig.ts
+++ b/src/createEslintConfig.ts
@@ -14,7 +14,7 @@ export async function createEslintConfig({
   pkg,
   rootDir,
   writeFile,
-}: CreateEslintConfigArgs): Promise<CLIEngine.Options['baseConfig']> {
+}: CreateEslintConfigArgs): Promise<CLIEngine.Options['baseConfig'] | void> {
   const isReactLibrary = Boolean(getReactVersion(pkg));
 
   const config = {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,8 +11,10 @@
     "module": "commonjs",
     "rootDir": "src",
     "strict": true,
-    "noImplicitAny": true,
     "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
     "skipLibCheck": true,
     "target": "es2017"
   }


### PR DESCRIPTION
- noUnusedParameters, noImplicitReturns, and noFallthroughCasesInSwitch
  - improve typings for 1 unused parameter and 1 implicit return

- also remove noImplicitAny as that's redundant with strict: true

This is the same level of strictness as in the templates and I believe the highest level of strictness (I use the same level in my own libraries too).

The description of `noImplicitReturns` is a bit different from the name, not sure if it would've helped with something like #371 or not.