### PR TITLE
(types): add @types/sade, fix transpileOnly default

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "@types/react": "^16.9.11",
     "@types/rollup-plugin-json": "^3.0.2",
     "@types/rollup-plugin-sourcemaps": "^0.4.2",
+    "@types/sade": "^1.6.0",
     "@types/semver": "^7.1.0",
     "doctoc": "^1.4.0",
     "husky": "^3.0.9",

--- a/src/createRollupConfig.ts
+++ b/src/createRollupConfig.ts
@@ -152,7 +152,7 @@ export async function createRollupConfig(
             target: 'esnext',
           },
         },
-        check: opts.transpileOnly === false,
+        check: !opts.transpileOnly,
       }),
       babelPluginTsdx({
         exclude: 'node_modules/**',

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -2,7 +2,6 @@ declare module 'asyncro';
 declare module 'enquirer';
 declare module 'jpjs';
 declare module 'ora';
-declare module 'sade';
 declare module 'tiny-glob/sync';
 declare module 'ansi-escapes';
 declare module 'eslint-config-react-app';

--- a/src/index.ts
+++ b/src/index.ts
@@ -294,7 +294,7 @@ prog
   .example('watch --onSuccess "echo Successful build!"')
   .option('--onFailure', 'Run a command on a failed build')
   .example('watch --onFailure "The build failed!"')
-  .option('--transpileOnly', 'Skip type checking', false)
+  .option('--transpileOnly', 'Skip type checking')
   .example('build --transpileOnly')
   .option('--extractErrors', 'Extract invariant errors to ./errors/codes.json.')
   .example('build --extractErrors')
@@ -397,7 +397,7 @@ prog
   .example('build --format cjs,esm')
   .option('--tsconfig', 'Specify custom tsconfig path')
   .example('build --tsconfig ./tsconfig.foo.json')
-  .option('--transpileOnly', 'Skip type checking', false)
+  .option('--transpileOnly', 'Skip type checking')
   .example('build --transpileOnly')
   .option(
     '--extractErrors',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1098,6 +1098,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/mri@*":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@types/mri/-/mri-1.1.0.tgz#66555e4d797713789ea0fefdae0898d8170bf5af"
+  integrity sha512-fMl88ZoZXOB7VKazJ6wUMpZc9QIn+jcigSFRf2K/rrw4DcXn+/uGxlWX8DDlcE7JkwgIZ7BDH+JgxZPlc/Ap3g==
+
 "@types/ms@^0.7.30":
   version "0.7.31"
   resolved "https://registry.yarnpkg.com/@types/ms/-/ms-0.7.31.tgz#31b7ca6407128a3d2bbc27fe2d21b345397f6197"
@@ -1178,6 +1183,13 @@
   dependencies:
     "@types/node" "*"
     rollup "^0.63.4"
+
+"@types/sade@^1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@types/sade/-/sade-1.6.0.tgz#eef2efa892b035b42693b00c554fc9713c6fefb2"
+  integrity sha512-Db3m69LUsLG4jqrJrf+X/IwwtvdxeazrDodWSNEcAGe60dxQJPXil9uNl2tJj6IRjjadNv2eDYV1XHM0utCSLQ==
+  dependencies:
+    "@types/mri" "*"
 
 "@types/semver@^7.1.0":
   version "7.1.0"


### PR DESCRIPTION
- transpileOnly default being the wrong type was found as a result of
  the better typing

I originally made this as a follow-up to #407 , as `prog` is passed around as an argument there (and is `any` without these types), but that hasn't gotten a response in almost a month now 😐 😐
So figured I'd separate it out.

Just as a note note, the `@types/sade` package was reviewed by DT, but never got a response from the maintainer, https://github.com/lukeed/sade/issues/27#issuecomment-554268697