### PR TITLE
(feat): support JS & JSX files in tsdx test

### DIFF
--- a/src/createJestConfig.ts
+++ b/src/createJestConfig.ts
@@ -5,11 +5,12 @@ export function createJestConfig(
   const config = {
     transform: {
       '.(ts|tsx)': require.resolve('ts-jest/dist'),
+      '.(js|jsx)': require.resolve('babel-jest'), // jest's default
     },
     transformIgnorePatterns: ['[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$'],
     moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
-    collectCoverageFrom: ['src/**/*.{ts,tsx}'],
-    testMatch: ['<rootDir>/**/*.(spec|test).{ts,tsx}'],
+    collectCoverageFrom: ['src/**/*.{ts,tsx,js,jsx}'],
+    testMatch: ['<rootDir>/**/*.(spec|test).{ts,tsx,js,jsx}'],
     testURL: 'http://localhost',
     rootDir,
     watchPlugins: [


### PR DESCRIPTION
- JS & JSX are already supported in tsdx build, so this is just adding
  some better parity in tsdx test
  - more JS & JSX support also means better support for gradual TS
    migrations

- JS + JSX spec files should also be ran, not just TS + TSX
  - run them with babel-jest, which is jest's default
    - changing transform meant babel-jest wasn't run on them anymore
  - notably, TSDX itself has tests written in JS, so TSDX would need
    this to dogfood itself
- also get coverage from JS + JSX files too

I'm currently adding TSDX in https://github.com/agilgur5/react-signature-canvas while migrating it to TS and these all came up as frustrations. Related to #383 which is also about parity for build vs. test