### PR TITLE
(feat): support JS & JSX files in tsdx lint

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -593,7 +593,7 @@ prog
           ...config,
           ...appPackageJson.eslint,
         },
-        extensions: ['.ts', '.tsx'],
+        extensions: ['.ts', '.tsx', '.js', '.jsx'],
         fix: opts.fix,
         ignorePattern: opts['ignore-pattern'],
       });

--- a/test/fixtures/build-withConfig/errors/ErrorDev.js
+++ b/test/fixtures/build-withConfig/errors/ErrorDev.js
@@ -1,9 +1,7 @@
-
 function ErrorDev(message) {
   const error = new Error(message);
   error.name = 'Invariant Violation';
   return error;
 }
 
-export default ErrorDev;      
-      
+export default ErrorDev;

--- a/test/fixtures/build-withConfig/errors/ErrorProd.js
+++ b/test/fixtures/build-withConfig/errors/ErrorProd.js
@@ -1,4 +1,3 @@
-
 function ErrorProd(code) {
   // TODO: replace this URL with yours
   let url = 'https://reactjs.org/docs/error-decoder.html?invariant=' + code;

--- a/test/fixtures/util.js
+++ b/test/fixtures/util.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const shell = require('shelljs');
 const path = require('path');
 const rootDir = process.cwd();

--- a/test/utils/psKill.js
+++ b/test/utils/psKill.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const psTree = require('ps-tree');
 
 // Loops through processes and kills them


### PR DESCRIPTION
- JS & JSX are already supported in tsdx build, so this is just adding
  some better parity in tsdx test
  - more JS & JSX support also means better support for gradual TS
    migrations

- prior to this, JS & JSX files wouldn't be linted unless explicitly
  included with a glob or something
  - extensions is also only configurable via CLIEngine, .eslintrc
    doesn't currently support it

- fix errors & warnings in JS test files as TSDX dogfoods its own lint
  functionality

I'm currently adding TSDX in https://github.com/agilgur5/react-signature-canvas while migrating it to TS and this came up as frustration. Related to #486 