### PR TITLE
(fix): parse tsconfig extends, trailing commas, and comments

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,7 @@
 import fs from 'fs-extra';
 import path from 'path';
 import camelCase from 'camelcase';
+
 import { PackageJson } from './types';
 
 // Remove the package name scope if it exists

--- a/test/fixtures/build-withTsconfig/tsconfig.base.json
+++ b/test/fixtures/build-withTsconfig/tsconfig.base.json
@@ -1,0 +1,30 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "lib": ["dom", "esnext"],
+    "declaration": true,
+    "declarationDir": "typings",
+    "declarationMap": true,
+    "sourceMap": true,
+    "rootDir": "./src",
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "strictPropertyInitialization": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "moduleResolution": "node",
+    "baseUrl": "./",
+    "paths": {
+      "*": ["src/*", "node_modules/*"]
+    },
+    "jsx": "react",
+    "esModuleInterop": true
+  },
+  "include": ["src", "types"], // test parsing of trailing comma & comment
+}

--- a/test/fixtures/build-withTsconfig/tsconfig.json
+++ b/test/fixtures/build-withTsconfig/tsconfig.json
@@ -1,30 +1,4 @@
 {
-  "compilerOptions": {
-    "module": "ESNext",
-    "lib": ["dom", "esnext"],
-    "declaration": true,
-    "declarationDir": "typings",
-    "declarationMap": true,
-    "sourceMap": true,
-    "rootDir": "./src",
-    "strict": true,
-    "noImplicitAny": true,
-    "strictNullChecks": true,
-    "strictFunctionTypes": true,
-    "strictPropertyInitialization": true,
-    "noImplicitThis": true,
-    "alwaysStrict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true,
-    "moduleResolution": "node",
-    "baseUrl": "./",
-    "paths": {
-      "*": ["src/*", "node_modules/*"]
-    },
-    "jsx": "react",
-    "esModuleInterop": true
-  },
-  "include": ["src", "types"]
+  // ensure that extends works (trailing comma & comment too)
+  "extends": "./tsconfig.base.json",
 }


### PR DESCRIPTION
- use ts.readConfigFile to properly parse a commas and comments from
  tsconfig instead of just trying to readJSON
- use ts.parseJsonConfigFileContent to properly parse `extends` and
  get recursive compilerOptions

- add tests for all of the above use cases
  - add them to build-withTsconfig which changes declarationDir;
    should only work if TSDX properly parses the tsconfig

NOTE: this is only necessary for internal, TSDX-specific parsing of
tsconfig.json. rollup-plugin-typescript2 already handles these options,
but internal options like esModuleInterop etc are also used & parsed
independently of rpts2

Fixes #483 ~with its own suggestion, eventually getting to https://github.com/facebook/create-react-app/pull/7248 as the solution~ **EDIT**: that only solved commas and comments, `extends` needed more work, see below comments.
Also fixes #484 as it's the same parser that does both. Still need to add tests for this case, thinking of just having all test fixtures extend a base fixture and then override it?

**This is built on top of #436 , please merge that first.**