### PR TITLE
(fix): jest shouldn't transform json files in node_modules

### DIFF
--- a/src/createJestConfig.ts
+++ b/src/createJestConfig.ts
@@ -6,7 +6,7 @@ export function createJestConfig(
     transform: {
       '.(ts|tsx)': require.resolve('ts-jest/dist'),
     },
-    transformIgnorePatterns: ['[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$'],
+    transformIgnorePatterns: ['[/\\\\]node_modules[/\\\\].+\\.(js|jsx|json)$'],
     moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
     collectCoverageFrom: ['src/**/*.{ts,tsx}'],
     testMatch: ['<rootDir>/**/*.(spec|test).{ts,tsx}'],


### PR DESCRIPTION
- not sure why ts-jest was picking these up and giving warnings, but
  TSDX's custom transformIgnorePatterns is different from jest's
  default (everything in node_modules), so set it to ignore json too

Fixes #161

@jaredpalmer is there a reason TSDX has a custom `transformIgnorePattern`? It's been like that since [one of the first commits](https://github.com/jaredpalmer/tsdx/commit/6bbf07793424511cc245f62f52694925fe452342) so idk.
[Jest's default](https://jestjs.io/docs/en/configuration#testpathignorepatterns-arraystring) is just `/node_modules/`, so not sure why TSDX's is slightly different. To allow for transforming TS files in `node_modules`?
