### PR TITLE
(test): use ts-node for tests for better testing DX

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,8 @@
     "pretty-quick": "^2.0.0",
     "ps-tree": "^1.2.0",
     "react": "^16.8.6",
-    "semver": "^7.1.1"
+    "semver": "^7.1.1",
+    "ts-node": "^8.6.2"
   },
   "husky": {
     "hooks": {

--- a/test/tests/tsdx-build.test.js
+++ b/test/tests/tsdx-build.test.js
@@ -8,6 +8,8 @@ const util = require('../fixtures/util');
 shell.config.silent = false;
 
 const stageName = 'stage-build';
+const buildCommand =
+  'ts-node --project ../tsconfig.json --files ../src/index.ts build';
 
 describe('tsdx build', () => {
   beforeAll(() => {
@@ -17,7 +19,7 @@ describe('tsdx build', () => {
   it('should compile files into a dist directory', () => {
     util.setupStageWithFixture(stageName, 'build-default');
 
-    const output = shell.exec('node ../dist/index.js build --format esm,cjs');
+    const output = shell.exec(`${buildCommand} --format esm,cjs`);
 
     expect(shell.test('-f', 'dist/index.js')).toBeTruthy();
     expect(
@@ -36,7 +38,7 @@ describe('tsdx build', () => {
   it('should create the library correctly', () => {
     util.setupStageWithFixture(stageName, 'build-default');
 
-    shell.exec('node ../dist/index.js build');
+    shell.exec(`${buildCommand}`);
 
     const lib = require(`../../${stageName}/dist`);
     expect(lib.foo()).toBe('bar');
@@ -48,7 +50,7 @@ describe('tsdx build', () => {
     shell.mv('package.json', 'package-og.json');
     shell.mv('package2.json', 'package.json');
 
-    const output = shell.exec('node ../dist/index.js build --format esm,cjs');
+    const output = shell.exec(`${buildCommand} --format esm,cjs`);
     expect(shell.test('-f', 'dist/index.js')).toBeTruthy();
 
     // build-default files have been cleaned out
@@ -80,13 +82,13 @@ describe('tsdx build', () => {
 
   it('should fail gracefully with exit code 1 when build failed', () => {
     util.setupStageWithFixture(stageName, 'build-invalid');
-    const code = shell.exec('node ../dist/index.js build').code;
+    const code = shell.exec(`${buildCommand}`).code;
     expect(code).toBe(1);
   });
 
   it('should only transpile and not type check', () => {
     util.setupStageWithFixture(stageName, 'build-invalid');
-    const code = shell.exec('node ../dist/index.js build --transpileOnly').code;
+    const code = shell.exec(`${buildCommand} --transpileOnly`).code;
 
     expect(shell.test('-f', 'dist/index.js')).toBeTruthy();
     expect(

--- a/yarn.lock
+++ b/yarn.lock
@@ -1411,6 +1411,11 @@ are-we-there-yet@~1.1.2:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
 
+arg@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
+
 argparse@^1.0.7:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
@@ -2323,6 +2328,11 @@ diff-sequences@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-24.9.0.tgz#5715d6244e2aa65f48bba0bc972db0b0b11e95b5"
   integrity sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew==
+
+diff@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
+  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 doctoc@^1.4.0:
   version "1.4.0"
@@ -4414,7 +4424,7 @@ make-dir@^3.0.0:
   dependencies:
     semver "^6.0.0"
 
-make-error@1.x:
+make-error@1.x, make-error@^1.1.1:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.5.tgz#efe4e81f6db28cadd605c70f29c831b58ef776c8"
   integrity sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==
@@ -6420,6 +6430,17 @@ ts-jest@^24.0.2:
     semver "^5.5"
     yargs-parser "10.x"
 
+ts-node@^8.6.2:
+  version "8.6.2"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.6.2.tgz#7419a01391a818fbafa6f826a33c1a13e9464e35"
+  integrity sha512-4mZEbofxGqLL2RImpe3zMJukvEvcO1XP8bj8ozBPySdCUXEcU5cIRwR0aM3R+VoZq7iXc8N86NC0FspGRqP4gg==
+  dependencies:
+    arg "^4.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    source-map-support "^0.5.6"
+    yn "3.1.1"
+
 tslib@1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
@@ -6876,3 +6897,8 @@ yargs@13.3.0, yargs@^13.3.0:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^13.1.1"
+
+yn@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==


### PR DESCRIPTION
- personally, I often forget to yarn build before yarn test and that
  means I'm testing stale changes
  - ts-node is one of the easiest ways to ensure the code isn't stale
    - but it comes at a big performance penalty, tests are about 1.5x
      slower, which is much longer than the additional time for
      yarn build

So I think the perf penalty here makes this a no-go, but figured I'd PR for posterity. See #493 as a somewhat similar alternative.

This was something I mentioned in https://github.com/jaredpalmer/tsdx/issues/381#issuecomment-576622565 but never got a response on 😐 😐 . Figured I might as well try and see what happens.

<hr>

Related to #289.
Would like to be able to support `jest --watch` for internal tests, but I believe that would require programmatic access to the CLI engine, which we don't currently have. #407 actually goes a long way toward this; it wouldn't be much work on top of it to expose the CLI actions as functions and then import those for internal tests.
Just importing functions and having them in-memory should be a perf improvement over the current re-running of CLI multiple times, and `jest --watch`s incremental testing should be a significant improvement

Could then leave `shelljs` stuff as integration tests (which are slower) which don't need to run locally for every change, but should continue running on CI.

A separate test perf improvement I was thinking of was having the temporary `stage-build` (and `stage-lint`) directory use a `tmpfs` like a RAMDisk or something, which should speed up the disk I/O considerably as the files be in-memory. Not sure how cross-platform this might be for the test matrix (and Windows contributors), but still have to investigate libraries for that.