### PR TITLE
(test): always run build before running tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build": "tsc -p tsconfig.json",
     "lint": "yarn build && yarn lint:post-build",
     "lint:post-build": "node dist/index.js lint src test --ignore-pattern 'test/tests/lint'",
-    "test": "jest --config ./test/jest.config.json",
+    "test": "yarn build && jest --config ./test/jest.config.json",
     "watch": "chokidar \"./package.json\" \"./src/**/*.ts\" \"node_modules\\@jaredpalmer\\rollup-plugin-preserve-shebang\\dist\\index.js\" -c \"yarn build && echo Success\"",
     "start": "tsc -p tsconfig.json --watch"
   },


### PR DESCRIPTION
- personally, I often forget to yarn build before yarn test and that
  means I'm testing stale changes
  - would be good to have a way to run jest --watch, but that would
    optimally require programmatic access to the CLI engine, which
    needs some refactoring

Alternative to #492 . Please read that issue for more on test perf improvements we can make to TSDX.

This isn't as robust as #492 but is significantly faster and works the same way as `yarn lint`.