### PR TITLE
(fix): jest config parsing shouldn't silently fail on error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -534,11 +534,13 @@ prog
       ),
       ...appPackageJson.jest,
     };
-    try {
-      // Allow overriding with jest.config
+
+    // Allow overriding with jest.config
+    const jestConfigExists = await fs.pathExists(paths.jestConfig);
+    if (jestConfigExists) {
       const jestConfigContents = require(paths.jestConfig);
       jestConfig = { ...jestConfig, ...jestConfigContents };
-    } catch {}
+    }
 
     argv.push(
       '--config',


### PR DESCRIPTION
- before if your jest.config.js had an error in it, the try/catch would
  just ignore it and pretend like your jest.config.js didn't exist
  - this caused me a lot of confusion as to why my customizations
    seemingly weren't being read at all

- instead of try/catching a MODULE_NOT_FOUND, check if it exists first,
  and only then do parsing
  - and let it throw an error if there is one, don't cover it up

Ran into this while making https://github.com/agilgur5/react-signature-canvas/pull/42/ as well, specifically https://github.com/agilgur5/react-signature-canvas/commit/8f124fe2be66b1e2d38d3844ca21ebf1221e56c4

Related to #483 which also had a silent parsing error due to an overbroad try/catch -- should really remove those from the codebase as they cause lots of confusing headaches to users