### PR TITLE
Add support for remote custom templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "sade": "^1.4.2",
     "shelljs": "^0.8.3",
     "tiny-glob": "^0.2.6",
+    "tmp-promise": "^2.0.2",
     "ts-jest": "^24.0.2",
     "tslib": "^1.9.3",
     "typescript": "^3.7.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6234,6 +6234,20 @@ tiny-glob@^0.2.6:
     globalyzer "^0.1.0"
     globrex "^0.1.1"
 
+tmp-promise@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/tmp-promise/-/tmp-promise-2.0.2.tgz#ee605edb10f100954be5dd8b9dbe1bfd56194202"
+  integrity sha512-zl71nFWjPKW2KXs+73gEk8RmqvtAeXPxhWDkTUoa3MSMkjq3I+9OeknjF178MQoMYsdqL730hfzvNfEkePxq9Q==
+  dependencies:
+    tmp "0.1.0"
+
+tmp@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.1.0.tgz#ee434a4e22543082e294ba6201dcc6eafefa2877"
+  integrity sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==
+  dependencies:
+    rimraf "^2.6.3"
+
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"


### PR DESCRIPTION
Proposal for #441 


Add support for custom remote templates:
```
tsdx create template --template https://github.com/benjlevesque/tsdx-template-basic my-app
```
Note: the repository must follow a specific structure
- there MUST be a `template` directory, containing the template files.
- there MIGHT be a `template.json` file, with the following structure:
```json
{
  "name": "...",
  "dependencies": [  ],
  "packageJson": {  }
}
```

Template structure & approach inspired from [CRA](https://github.com/facebook/create-react-app/tree/master/packages/cra-template).