### PR TITLE
(fix): set rootDir to './src', not './'. deprecate moveTypes

### DIFF
--- a/src/deprecated.ts
+++ b/src/deprecated.ts
@@ -20,7 +20,9 @@ export async function moveTypes() {
   console.warn(
     '[tsdx]: Your rootDir is currently set to "./". Please change your ' +
       'rootDir to "./src".\n' +
-      'TSDX has deprecated setting tsconfig.compilerOptions.rootDir to "./".'
+      'TSDX has deprecated setting tsconfig.compilerOptions.rootDir to ' +
+      '"./" as it caused buggy output for declarationMaps and occassionally ' +
+      'for type declarations themselves.'
   );
 
   try {

--- a/src/deprecated.ts
+++ b/src/deprecated.ts
@@ -1,0 +1,41 @@
+import * as fs from 'fs-extra';
+
+import { paths } from './constants';
+
+/*
+  This was originally needed because the default
+  tsconfig.compilerOptions.rootDir was set to './' instead of './src'.
+  Now that it's set to './src', this is now deprecated.
+  To ensure a stable upgrade path for users, leave the warning in for
+  6 months - 1 year, then change it to an error in a breaking bump and leave
+  that in for some time too.
+*/
+export async function moveTypes() {
+  const appDistSrc = paths.appDist + '/src';
+
+  const pathExists = await fs.pathExists(appDistSrc);
+  if (!pathExists) return;
+
+  // see note above about deprecation window
+  console.warn(
+    '[tsdx]: Your rootDir is currently set to "./". Please change your ' +
+      'rootDir to "./src".\n' +
+      'TSDX has deprecated setting tsconfig.compilerOptions.rootDir to "./".'
+  );
+
+  try {
+    // Move the typescript types to the base of the ./dist folder
+    await fs.copy(appDistSrc, paths.appDist, {
+      overwrite: true,
+    });
+  } catch (err) {
+    // ignore errors about the destination dir already existing or files not
+    // existing as those always occur for some reason, re-throw any other
+    // unexpected failures
+    if (err.code !== 'EEXIST' && err.code !== 'ENOENT') {
+      throw err;
+    }
+  }
+
+  await fs.remove(appDistSrc);
+}

--- a/src/deprecated.ts
+++ b/src/deprecated.ts
@@ -34,6 +34,8 @@ export async function moveTypes() {
     // ignore errors about the destination dir already existing or files not
     // existing as those always occur for some reason, re-throw any other
     // unexpected failures
+    // NOTE: these errors mean that sometimes files don't get moved properly,
+    // meaning that it's buggy / unreliable (see console.warn above)
     if (err.code !== 'EEXIST' && err.code !== 'ENOENT') {
       throw err;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,7 @@ import {
 import { createProgressEstimator } from './createProgressEstimator';
 import { templates } from './templates';
 import { composePackageJson } from './templates/utils';
+import * as deprecated from './deprecated';
 const pkg = require('../package.json');
 
 const prog = sade('tsdx');
@@ -97,29 +98,6 @@ async function getInputs(
     .forEach(input => inputs.push(input));
 
   return concatAllArray(inputs);
-}
-
-async function moveTypes() {
-  const appDistSrc = paths.appDist + '/src';
-
-  const pathExists = await fs.pathExists(appDistSrc);
-  if (!pathExists) return;
-
-  try {
-    // Move the typescript types to the base of the ./dist folder
-    await fs.copy(appDistSrc, paths.appDist, {
-      overwrite: true,
-    });
-  } catch (err) {
-    // ignore errors about the destination dir already existing or files not
-    // existing as those always occur for some reason, re-throw any other
-    // unexpected failures
-    if (err.code !== 'EEXIST' && err.code !== 'ENOENT') {
-      throw err;
-    }
-  }
-
-  await fs.remove(appDistSrc);
 }
 
 prog
@@ -380,7 +358,7 @@ prog
 `);
 
         try {
-          await moveTypes();
+          await deprecated.moveTypes();
 
           if (firstTime && opts.onFirstSuccess) {
             firstTime = false;
@@ -431,7 +409,7 @@ prog
           async (inputOptions: RollupOptions & { output: OutputOptions }) => {
             let bundle = await rollup(inputOptions);
             await bundle.write(inputOptions.output);
-            await moveTypes();
+            await deprecated.moveTypes();
           }
         )
         .catch((e: any) => {

--- a/templates/basic/tsconfig.json
+++ b/templates/basic/tsconfig.json
@@ -6,7 +6,7 @@
     "importHelpers": true,
     "declaration": true,
     "sourceMap": true,
-    "rootDir": "./",
+    "rootDir": "./src",
     "strict": true,
     "noImplicitAny": true,
     "strictNullChecks": true,

--- a/templates/react-with-storybook/tsconfig.json
+++ b/templates/react-with-storybook/tsconfig.json
@@ -6,7 +6,7 @@
     "importHelpers": true,
     "declaration": true,
     "sourceMap": true,
-    "rootDir": "./",
+    "rootDir": "./src",
     "strict": true,
     "noImplicitAny": true,
     "strictNullChecks": true,

--- a/templates/react/tsconfig.json
+++ b/templates/react/tsconfig.json
@@ -6,7 +6,7 @@
     "importHelpers": true,
     "declaration": true,
     "sourceMap": true,
-    "rootDir": "./",
+    "rootDir": "./src",
     "strict": true,
     "noImplicitAny": true,
     "strictNullChecks": true,

--- a/test/fixtures/build-default/tsconfig.json
+++ b/test/fixtures/build-default/tsconfig.json
@@ -4,7 +4,7 @@
     "lib": ["dom", "esnext"],
     "declaration": true,
     "sourceMap": true,
-    "rootDir": "./",
+    "rootDir": "./src",
     "strict": true,
     "noImplicitAny": true,
     "strictNullChecks": true,

--- a/test/fixtures/build-invalid/tsconfig.json
+++ b/test/fixtures/build-invalid/tsconfig.json
@@ -4,7 +4,7 @@
     "lib": ["dom", "esnext"],
     "declaration": true,
     "sourceMap": true,
-    "rootDir": "./",
+    "rootDir": "./src",
     "strict": true,
     "noImplicitAny": true,
     "strictNullChecks": true,

--- a/test/fixtures/build-withConfig/tsconfig.json
+++ b/test/fixtures/build-withConfig/tsconfig.json
@@ -4,7 +4,7 @@
     "lib": ["dom", "esnext"],
     "declaration": true,
     "sourceMap": true,
-    "rootDir": "./",
+    "rootDir": "./src",
     "strict": true,
     "noImplicitAny": true,
     "strictNullChecks": true,


### PR DESCRIPTION
- rootDir needed to be changed to ./src because the previous ./ caused
  type declarations to be generated in dist/src/ instead of just dist/
  - the moveTypes function handled moving the declarations back into
    dist/, but occassionally had errors moving .d.ts files
    - particularly in CI and for projects with many of them
    - declarationMap (*.d.ts.map) files would also have issues due to
      the hackiness of moveTypes, setting to rootDir to './src' is one
      of the necessary steps in fixing them

- deprecate moveTypes and add a warning with instructions if it is used
  when a rootDir of './' is detected
  - add notes about a deprecation window in the comments

<hr>

Split out from #488 and **built on top of #500 (please merge that first)** . 
- Per https://github.com/jaredpalmer/tsdx/pull/500#issuecomment-583643567, I suspect that `fs.copy` issues being called inside of `moveTypes` is the root cause of the _very frequent_ CI issues we've had with missing `.d.ts.` files, which I've occasionally replicated locally (I saw it locally first and then it started happening more in CI).
  - Will try to re-run CI a few times here to get some results
- #488 goes into more details about the breaking change of changing `rootDir`, so here I've deprecated with a warning + instructions instead of fully removing it. I've also moved it to a `deprecated.ts` file with a clear notice in a comment.
  - As this changes the templates, this should be released sooner rather than later to stop the bleeding, which is another reason to split it off of #488 (#488 depends on this fix, so this can go first but not vice-versa. and #488 is dependent on #468 which still hasn't been merged)
