### PR TITLE
fix: anchor regexps in Jest transforms for proper JSON handling

### DIFF
--- a/src/createJestConfig.ts
+++ b/src/createJestConfig.ts
@@ -4,8 +4,8 @@ export function createJestConfig(
 ) {
   const config = {
     transform: {
-      '.(ts|tsx)': require.resolve('ts-jest/dist'),
-      '.(js|jsx)': require.resolve('babel-jest'), // jest's default
+      '.(ts|tsx)$': require.resolve('ts-jest/dist'),
+      '.(js|jsx)$': require.resolve('babel-jest'), // jest's default
     },
     transformIgnorePatterns: ['[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$'],
     moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],


### PR DESCRIPTION
Master has a new regexp for Jest which breaks tests that reference JSON at some point in the dependency chain. This is a fix.

The regexp `.(js|jsx)` matches `.json` which means Jest attempts to load JSON files as JS modules. Since they aren't modules, Jest fails.