### PR TITLE
Add JSX extension to @rollup/plugin-node-resolve options

### DIFF
--- a/src/createRollupConfig.ts
+++ b/src/createRollupConfig.ts
@@ -108,6 +108,7 @@ export async function createRollupConfig(
           'main',
           opts.target !== 'node' ? 'browser' : undefined,
         ].filter(Boolean) as string[],
+        // defaults + .jsx
         extensions: ['.mjs', '.js', '.jsx', '.json', '.node'],
       }),
       opts.format === 'umd' &&

--- a/src/createRollupConfig.ts
+++ b/src/createRollupConfig.ts
@@ -108,6 +108,7 @@ export async function createRollupConfig(
           'main',
           opts.target !== 'node' ? 'browser' : undefined,
         ].filter(Boolean) as string[],
+        extensions: ['.mjs', '.js', '.jsx', '.json', '.node'],
       }),
       opts.format === 'umd' &&
         commonjs({

--- a/test/fixtures/build-default/src/index.ts
+++ b/test/fixtures/build-default/src/index.ts
@@ -1,6 +1,8 @@
 import './syntax/nullish-coalescing';
 import './syntax/optional-chaining';
 
+import './syntax/jsx-import/JSX-import-JSX';
+
 export { foo } from './foo';
 
 export const sum = (a: number, b: number) => {

--- a/test/fixtures/build-default/src/syntax/jsx-import/JSX-A.jsx
+++ b/test/fixtures/build-default/src/syntax/jsx-import/JSX-A.jsx
@@ -1,0 +1,7 @@
+// DO NOT IMPORT THIS FILE DIRECTLY FROM index.ts
+// THIS FILE IS INTENTIONALLY TO TEST JSX CHAINING IMPORT
+// SEE https://github.com/jaredpalmer/tsdx/issues/523#issuecomment-592662499
+
+import JSXB from './JSX-B';
+
+export default JSXB;

--- a/test/fixtures/build-default/src/syntax/jsx-import/JSX-A.jsx
+++ b/test/fixtures/build-default/src/syntax/jsx-import/JSX-A.jsx
@@ -1,6 +1,6 @@
 // DO NOT IMPORT THIS FILE DIRECTLY FROM index.ts
 // THIS FILE IS INTENTIONALLY TO TEST JSX CHAINING IMPORT
-// SEE https://github.com/jaredpalmer/tsdx/issues/523#issuecomment-592662499
+// SEE https://github.com/jaredpalmer/tsdx/issues/523
 
 import JSXB from './JSX-B';
 

--- a/test/fixtures/build-default/src/syntax/jsx-import/JSX-B.jsx
+++ b/test/fixtures/build-default/src/syntax/jsx-import/JSX-B.jsx
@@ -1,6 +1,6 @@
 // DO NOT IMPORT THIS FILE DIRECTLY FROM index.ts
 // THIS FILE IS INTENTIONALLY TO TEST JSX CHAINING IMPORT
-// SEE https://github.com/jaredpalmer/tsdx/issues/523#issuecomment-592662499
+// SEE https://github.com/jaredpalmer/tsdx/issues/523
 
 export default function JSXComponent() {
   return 'JSXC';

--- a/test/fixtures/build-default/src/syntax/jsx-import/JSX-B.jsx
+++ b/test/fixtures/build-default/src/syntax/jsx-import/JSX-B.jsx
@@ -1,0 +1,7 @@
+// DO NOT IMPORT THIS FILE DIRECTLY FROM index.ts
+// THIS FILE IS INTENTIONALLY TO TEST JSX CHAINING IMPORT
+// SEE https://github.com/jaredpalmer/tsdx/issues/523#issuecomment-592662499
+
+export default function JSXComponent() {
+  return 'JSXC';
+}

--- a/test/fixtures/build-default/src/syntax/jsx-import/JSX-import-JSX.jsx
+++ b/test/fixtures/build-default/src/syntax/jsx-import/JSX-import-JSX.jsx
@@ -1,0 +1,4 @@
+// Testing for jsx chaining import
+// https://github.com/jaredpalmer/tsdx/issues/523
+
+export * from './JSX-A';


### PR DESCRIPTION
close #523 

Add JSX extension to rollup `@rollup/plugin-node-resolve` plugin 

[The default extensions value](https://github.com/rollup/plugins/blob/b6621262e284057e5740089388ffdcc6c391998d/packages/node-resolve/src/index.js#L25) doesn't include the `.jsx` and It causes an error when import `jsx` from `js` file.

