### PR TITLE
(feat): support custom jest config paths via --config

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "build": "tsc -p tsconfig.json",
     "lint": "yarn build && yarn lint:post-build",
     "lint:post-build": "node dist/index.js lint src test --ignore-pattern 'test/tests/lint'",
-    "test": "yarn build && jest --config ./test/jest.config.json",
+    "test": "yarn build && yarn test:post-build",
+    "test:post-build": "node dist/index.js test --config ./test/jest.config.json",
     "watch": "chokidar \"./package.json\" \"./src/**/*.ts\" \"node_modules\\@jaredpalmer\\rollup-plugin-preserve-shebang\\dist\\index.js\" -c \"yarn build && echo Success\"",
     "start": "tsc -p tsconfig.json --watch"
   },

--- a/src/createJestConfig.ts
+++ b/src/createJestConfig.ts
@@ -1,8 +1,12 @@
+import { Config } from '@jest/types';
+
+export type JestConfigOptions = Partial<Config.InitialOptions>;
+
 export function createJestConfig(
   _: (relativePath: string) => void,
   rootDir: string
-) {
-  const config = {
+): JestConfigOptions {
+  const config: JestConfigOptions = {
     transform: {
       '.(ts|tsx)$': require.resolve('ts-jest/dist'),
       '.(js|jsx)$': require.resolve('babel-jest'), // jest's default

--- a/src/index.ts
+++ b/src/index.ts
@@ -508,7 +508,7 @@ prog
     let jestConfig = {
       ...createJestConfig(
         relativePath => path.resolve(__dirname, '..', relativePath),
-        paths.appRoot
+        opts.config ? path.dirname(opts.config) : paths.appRoot
       ),
       ...appPackageJson.jest,
     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -493,7 +493,7 @@ prog
   .describe(
     'Run jest test runner in watch mode. Passes through all flags directly to Jest'
   )
-  .action(async () => {
+  .action(async (opts: { config?: string }) => {
     // Do this as the first thing so that any code reading it knows the right env.
     process.env.BABEL_ENV = 'test';
     process.env.NODE_ENV = 'test';
@@ -514,10 +514,27 @@ prog
     };
 
     // Allow overriding with jest.config
-    const jestConfigExists = await fs.pathExists(paths.jestConfig);
-    if (jestConfigExists) {
-      const jestConfigContents = require(paths.jestConfig);
+    const defaultPathExists = await fs.pathExists(paths.jestConfig);
+    if (opts.config || defaultPathExists) {
+      const jestConfigPath = resolveApp(opts.config || paths.jestConfig);
+      const jestConfigContents = require(jestConfigPath);
       jestConfig = { ...jestConfig, ...jestConfigContents };
+    }
+
+    // if custom path, delete the arg as it's already been merged
+    if (opts.config) {
+      let configIndex = argv.indexOf('--config');
+      if (configIndex !== -1) {
+        // case of "--config path", delete both args
+        argv.splice(configIndex, 2);
+      } else {
+        // case of "--config=path", only one arg to delete
+        const configRegex = /--config=.+/;
+        configIndex = argv.findIndex(arg => arg.match(configRegex));
+        if (configIndex !== -1) {
+          argv.splice(configIndex, 1);
+        }
+      }
     }
 
     argv.push(

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ import semver from 'semver';
 import { paths } from './constants';
 import * as Messages from './messages';
 import { createBuildConfigs } from './createBuildConfigs';
-import { createJestConfig } from './createJestConfig';
+import { createJestConfig, JestConfigOptions } from './createJestConfig';
 import { createEslintConfig } from './createEslintConfig';
 import {
   resolveApp,
@@ -505,7 +505,7 @@ prog
     });
 
     const argv = process.argv.slice(2);
-    let jestConfig = {
+    let jestConfig: JestConfigOptions = {
       ...createJestConfig(
         relativePath => path.resolve(__dirname, '..', relativePath),
         opts.config ? path.dirname(opts.config) : paths.appRoot
@@ -517,7 +517,7 @@ prog
     const defaultPathExists = await fs.pathExists(paths.jestConfig);
     if (opts.config || defaultPathExists) {
       const jestConfigPath = resolveApp(opts.config || paths.jestConfig);
-      const jestConfigContents = require(jestConfigPath);
+      const jestConfigContents: JestConfigOptions = require(jestConfigPath);
       jestConfig = { ...jestConfig, ...jestConfigContents };
     }
 

--- a/test/jest.config.json
+++ b/test/jest.config.json
@@ -1,6 +1,5 @@
 {
   "testEnvironment": "node",
-  "rootDir": "./test",
   "roots": ["<rootDir>/tests"],
   "collectCoverageFrom": ["**/*.js"],
   "transform": {

--- a/test/jest.config.json
+++ b/test/jest.config.json
@@ -1,5 +1,6 @@
 {
   "testEnvironment": "node",
+  "rootDir": "./test",
   "roots": ["<rootDir>/tests"],
   "collectCoverageFrom": ["**/*.js"],
   "transform": {


### PR DESCRIPTION
- --config will now be parsed shallow merged with the defaults,
  just like package.json.jest already is

- previously adding --config to tsdx test would result in jest
  outputting a usage prompt (I believe due to the second --config
  that's added internally) and then the somewhat cryptic
  "argv.config.match is not a function"
  - if --config is detected, it will be parsed, merged, and then
    deleted from argv so that this error doesn't occur anymore

Also dogfood `tsdx test` internally (this was the last thing needed for it to be possible) & improve Jest config typings

Fixes #150 , or rather what's left of it after #229 .