### PR TITLE
(fix/docs): `test` script doesn't run Jest in interactive mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,7 @@ The package is optimized and bundled with Rollup into multiple formats (CommonJS
 
 ### `npm test` or `yarn test`
 
-Runs the test watcher (Jest) in an interactive mode.
-By default, runs tests related to files changed since the last commit.
+Runs your tests using Jest.
 
 ### `npm run lint` or `yarn lint`
 


### PR DESCRIPTION
- these docs actually predate the CI=true [addition](https://github.com/jaredpalmer/tsdx/pull/366) & [removal](https://github.com/jaredpalmer/tsdx/pull/421), not sure
  why they said it runs in interactive mode

This was mentioned in https://github.com/jaredpalmer/tsdx/issues/270#issuecomment-584949460