### PR TITLE
(fix): don't treat @/ ~/ alias as external module

### DIFF
--- a/src/createRollupConfig.ts
+++ b/src/createRollupConfig.ts
@@ -56,6 +56,12 @@ export async function createRollupConfig(
       if (id === 'babel-plugin-transform-async-to-promises/helpers') {
         return false;
       }
+      /**
+       * ~/ or @/ for srcDir
+       */
+      if (id.startsWith('@/') || id.startsWith('~/')) {
+        return false;
+      }
       return external(id);
     },
     // Rollup has treeshaking by default, but we can optimize it further...


### PR DESCRIPTION
### Current Behavior

Treating none relative import as external.

### Desired Behavior

I know TSDX absolute import is under [discussion](https://github.com/jaredpalmer/tsdx/issues/91) right now.

But can we start supporting `@/` and `~/` as an alias of srcDir?

It's widely used in Nuxt community, see [documentation](https://nuxtjs.org/guide/directory-structure/#aliases)

### Suggested Solution

Don't treat import path that startsWith `@/` and `~/` as external.

So people can write their own absolute import plugin like this:

```js
function rollupPluginAbsoluteImport() {
  return {
    name: "rollup-plugin-absolute-import",
    resolveId(source: string) {
      if (source.startsWith("@/") || source.startsWith("~/")) {
        return path.resolve(paths.appSrc, "." + source.slice(1, source.length));
      }
      return null;
    }
  };
}
```

### Who does this impact? Who is this for?

All users who can't wait to use absolute import path

### Describe alternatives you've considered

There is no way to use the absolute import path for TSDX right now I think.

I tried a lot of rollup plugins...

### Additional context

Maybe release more often?