### PR TITLE
(fix/types): fix internal & external declaration errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "chokidar-cli": "^1.2.2",
     "cross-env": "7.0.0",
     "cross-spawn": "^6.0.5",
-    "enquirer": "^2.3.0",
+    "enquirer": "^2.3.4",
     "eslint": "^6.1.0",
     "eslint-config-prettier": "^6.0.0",
     "eslint-config-react-app": "^5.0.2",

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -10,7 +10,7 @@ declare module 'eslint-config-react-app';
 // @see line 226 of https://unpkg.com/@babel/core@7.4.4/lib/index.js
 declare module '@babel/core' {
   export const DEFAULT_EXTENSIONS: string[];
-  export function createConfigItem(boop: any[], options: any) {}
+  export function createConfigItem(boop: any[], options: any): any[];
 }
 
 // Rollup plugins

--- a/yarn.lock
+++ b/yarn.lock
@@ -2394,10 +2394,10 @@ end-of-stream@^1.1.0:
   dependencies:
     once "^1.4.0"
 
-enquirer@^2.3.0:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.3.2.tgz#1c30284907cadff5ed2404bd8396036dd3da070e"
-  integrity sha512-PLhTMPUXlnaIv9D3Cq3/Zr1xb7soeDDgunobyCmYLUG19n24dvC8i+ZZgm2DekGpDnx7JvFSHV7lxfM58PMtbA==
+enquirer@^2.3.4:
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.3.4.tgz#c608f2e1134c7f68c1c9ee056de13f9b31076de9"
+  integrity sha512-pkYrrDZumL2VS6VBGDhqbajCM2xpkUNLuKfGPjfKaSIBKYopQbqEFyrOkRMIb2HDR/rO1kGhEt/5twBwtzKBXw==
   dependencies:
     ansi-colors "^3.2.1"
 


### PR DESCRIPTION
- basically skipLibCheck: false should pass

- Babel declaration shouldn't have function braces and should have a
  return type
- enquirer had some typings changes in [2.3.4](https://github.com/enquirer/enquirer/blob/master/CHANGELOG.md#234---2020-01-13), seems to be due to
  changes in @types/node

Partially mentioned in https://github.com/jaredpalmer/tsdx/issues/529#issuecomment-594383051, though I found these separately/unintentionally while writing #544