### PR TITLE
(deps/fix/types): upgrade rollup & fix event type issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "pascal-case": "^2.0.1",
     "prettier": "^1.19.1",
     "progress-estimator": "^0.2.2",
-    "rollup": "^1.27.8",
+    "rollup": "^1.32.1",
     "rollup-plugin-babel": "^4.3.2",
     "rollup-plugin-sourcemaps": "^0.4.2",
     "rollup-plugin-terser": "^5.1.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -322,7 +322,7 @@ prog
     }
 
     const spinner = ora().start();
-    await watch(
+    watch(
       (buildConfigs as RollupWatchOptions[]).map(inputOptions => ({
         watch: {
           silent: true,
@@ -342,11 +342,6 @@ prog
         spinner.start(chalk.bold.cyan('Compiling modules...'));
       }
       if (event.code === 'ERROR') {
-        spinner.fail(chalk.bold.red('Failed to compile'));
-        logError(event.error);
-        failureKiller = run(opts.onFailure);
-      }
-      if (event.code === 'FATAL') {
         spinner.fail(chalk.bold.red('Failed to compile'));
         logError(event.error);
         failureKiller = run(opts.onFailure);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5656,10 +5656,10 @@ rollup@^0.63.4:
     "@types/estree" "0.0.39"
     "@types/node" "*"
 
-rollup@^1.27.8:
-  version "1.27.8"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.27.8.tgz#94288a957af9f4c2380b73a17494d87705997d0f"
-  integrity sha512-EVoEV5rAWl+5clnGznt1KY8PeVkzVQh/R0d2s3gHEkN7gfoyC4JmvIVuCtPbYE8NM5Ep/g+nAmvKXBjzaqTsHA==
+rollup@^1.32.1:
+  version "1.32.1"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.32.1.tgz#4480e52d9d9e2ae4b46ba0d9ddeaf3163940f9c4"
+  integrity sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==
   dependencies:
     "@types/estree" "*"
     "@types/node" "*"


### PR DESCRIPTION
- if TSDX were installed directly from git, the `prepare` script would
  for some reason fail on these events
  - but they wouldn't error when run internally
    - when Rollup was upgraded, then they started erroring

- also remove the unnecessary await in front of watch

So this fixes, partially, #512 's issue with the `prepare` script erroring out.
The event type issues might be related to `@types/node` changes like mentioned in #542, but idk, I didn't investigate remotely.

Also supersedes #295 and #317, which were probably failing due to the old missing `.d.ts` errors that were fixed with #504 