### PR TITLE
(fix): correctly read tsconfig esModuleInterop

### DIFF
--- a/src/createRollupConfig.ts
+++ b/src/createRollupConfig.ts
@@ -95,7 +95,7 @@ export async function createRollupConfig(
       // (i.e. import * as namespaceImportObject from...) that are accessed dynamically.
       freeze: false,
       // Respect tsconfig esModuleInterop when setting __esModule.
-      esModule: tsCompilerOptions ? tsCompilerOptions.esModuleInterop : false,
+      esModule: Boolean(tsCompilerOptions?.esModuleInterop),
       name: opts.name || safeVariableName(opts.name),
       sourcemap: true,
       globals: { react: 'React', 'react-native': 'ReactNative' },

--- a/test/fixtures/build-withTsconfig/tsconfig.base.json
+++ b/test/fixtures/build-withTsconfig/tsconfig.base.json
@@ -24,7 +24,7 @@
       "*": ["src/*", "node_modules/*"]
     },
     "jsx": "react",
-    "esModuleInterop": true
+    "esModuleInterop": false
   },
   "include": ["src", "types"], // test parsing of trailing comma & comment
 }

--- a/test/tests/tsdx-build.test.js
+++ b/test/tests/tsdx-build.test.js
@@ -40,6 +40,7 @@ describe('tsdx build', () => {
 
     const lib = require(`../../${stageName}/dist`);
     expect(lib.foo()).toBe('bar');
+    expect(lib.__esModule).toBe(true);
   });
 
   it('should clean the dist directory before rebuilding', () => {
@@ -119,6 +120,18 @@ describe('tsdx build', () => {
     expect(shell.test('-f', 'dist/index.d.ts')).toBeFalsy();
     expect(shell.test('-f', 'typings/index.d.ts')).toBeTruthy();
     expect(shell.test('-f', 'typings/index.d.ts.map')).toBeTruthy();
+
+    expect(output.code).toBe(0);
+  });
+
+  it('should set __esModule according to esModuleInterop in tsconfig', () => {
+    util.setupStageWithFixture(stageName, 'build-withTsconfig');
+
+    const output = shell.exec('node ../dist/index.js build --format cjs');
+
+    const lib = require(`../../${stageName}/dist/build-withtsconfig.cjs.production.min.js`);
+    // if esModuleInterop: false, no __esModule is added, therefore undefined
+    expect(lib.__esModule).toBe(undefined);
 
     expect(output.code).toBe(0);
   });


### PR DESCRIPTION
- it's a property of compilerOptions, not of overall tsconfig
  - i.e. tsconfig.compilerOptions.esModuleInterop

- because this was incorrectly read, Rollup's esModule would always
  be set to `undefined`, and Rollup would then default to `true`
  - so esModuleInterop still wasn't being respected properly, I just
    shifted the defaults when I incorrectly patched this :/

(test): add tests for the default tsconfig as well as for when it's
explicitly set to false

Fixes #469 . Actually this was unintentionally fixed by me a short while ago when I updated #489 , but this improves the syntax and adds tests

This is a follow-up on bugs in #327 