### PR TITLE
(test): ensure custom --tsconfig path is correctly read

### DIFF
--- a/test/fixtures/build-withTsconfig/src/tsconfig.json
+++ b/test/fixtures/build-withTsconfig/src/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  // ensure that extends works (trailing comma & comment too)
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "declarationDir": "../typingsCustom/"
+  }
+}

--- a/test/tests/tsdx-build.test.js
+++ b/test/tests/tsdx-build.test.js
@@ -136,6 +136,28 @@ describe('tsdx build', () => {
     expect(output.code).toBe(0);
   });
 
+  it('should read custom --tsconfig path', () => {
+    util.setupStageWithFixture(stageName, 'build-withTsconfig');
+
+    const output = shell.exec(
+      'node ../dist/index.js build --format cjs --tsconfig ./src/tsconfig.json'
+    );
+
+    expect(shell.test('-f', 'dist/index.js')).toBeTruthy();
+    expect(
+      shell.test('-f', 'dist/build-withtsconfig.cjs.development.js')
+    ).toBeTruthy();
+    expect(
+      shell.test('-f', 'dist/build-withtsconfig.cjs.production.min.js')
+    ).toBeTruthy();
+
+    expect(shell.test('-f', 'dist/index.d.ts')).toBeFalsy();
+    expect(shell.test('-f', 'typingsCustom/index.d.ts')).toBeTruthy();
+    expect(shell.test('-f', 'typingsCustom/index.d.ts.map')).toBeTruthy();
+
+    expect(output.code).toBe(0);
+  });
+
   afterEach(() => {
     util.teardownStage(stageName);
   });


### PR DESCRIPTION
- this never had tests for it, so ensure it's properly read
  - make sure extends works, that an override works, and that paths
    are correctly resolved

Basically ensure that #436 works