### PR TITLE
Add 'src' to package.json files to improve source maps

### DIFF
--- a/src/templates/basic.ts
+++ b/src/templates/basic.ts
@@ -11,7 +11,7 @@ const basicTemplate: Template = {
     main: 'dist/index.js',
     // module: `dist/${safeName}.esm.js`,
     typings: `dist/index.d.ts`,
-    files: ['dist'],
+    files: ['dist', 'src'],
     engines: {
       node: '>=10',
     },


### PR DESCRIPTION
- so library users can actually view source, add breakpoints there,
  etc, etc and not only view types and dist files

Co-authored-by: Anton Gilgur <agilgur5@gmail.com>

Updated version of #252 with credit to original author. See https://github.com/jaredpalmer/tsdx/pull/252#issuecomment-599875270 and #494 for more context on why this is good to support