### PR TITLE
(optim/ci): don't build a second time for lint or test

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -21,7 +21,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Lint codebase
-        run: yarn lint
+        run: yarn lint:post-build
 
   test:
     runs-on: ${{ matrix.os }}
@@ -44,4 +44,4 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Test package
-        run: yarn test --runInBand
+        run: yarn test:post-build --runInBand


### PR DESCRIPTION
- yarn install already builds, so we can skip the build step of these
  scripts and run the post-build step of each instead