### PR TITLE
(ci): remove experimental --runInBand as tests pass now

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -44,4 +44,4 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Test package
-        run: yarn test:post-build --runInBand
+        run: yarn test:post-build


### PR DESCRIPTION
- this was added as an attempt to fix persistent CI errors that were
  occurring due to the now deprecated `moveTypes()` function
  - now that those have been fixed, this is no longer needed and should
    have a small speed bump by removing this
  - though it's possible --runInBand fixed a different CI error that
    happened less frequently: `EPERM` on creating directories on
    Windows, not sure, will find out

Basically a revert of #429 since #504 fixed the root cause behind most of the CI issues. If the Windows `EPERM` errors start happening again, we can revert this revert and then we'll know the `--runInBand` flag actually fixes it and that it's some type of race condition or something.
This was split out from #621 where CI passed a couple times with these changes