### PR TITLE
(ci/optim): add caching for yarn install

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -17,8 +17,8 @@ jobs:
         with:
           node-version: 10.x
 
-      - name: Install deps and build
-        run: yarn install --frozen-lockfile
+      - name: Install deps and build (with cache)
+        uses: bahmutov/npm-install@v1
 
       - name: Lint codebase
         run: yarn lint
@@ -40,8 +40,8 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
-      - name: Install deps and build
-        run: yarn install --frozen-lockfile
+      - name: Install deps and build (with cache)
+        uses: bahmutov/npm-install@v1
 
       - name: Test package
         run: yarn test --runInBand


### PR DESCRIPTION
- via [bahmutov/npm-install](https://github.com/bahmutov/npm-install)
- it handles all the cache steps, yarn vs. npm, OS differences, etc