### PR TITLE
(clean): remove unused fixture test directories

### DIFF
--- a/test/fixtures/build-default/test/blah.test.ts
+++ b/test/fixtures/build-default/test/blah.test.ts
@@ -1,7 +1,0 @@
-import { sum } from '../src';
-
-describe('fuck', () => {
-  it('works', () => {
-    expect(sum(1, 1)).toEqual(2);
-  });
-});

--- a/test/fixtures/build-withConfig/test/blah.test.ts
+++ b/test/fixtures/build-withConfig/test/blah.test.ts
@@ -1,7 +1,0 @@
-import { sum } from '../src';
-
-describe('fuck', () => {
-  it('works', () => {
-    expect(sum(1, 1)).toEqual(2);
-  });
-});

--- a/test/fixtures/build-withTsconfig/test/blah.test.ts
+++ b/test/fixtures/build-withTsconfig/test/blah.test.ts
@@ -1,7 +1,0 @@
-import { sum } from '../src';
-
-describe('fuck', () => {
-  it('works', () => {
-    expect(sum(1, 1)).toEqual(2);
-  });
-});


### PR DESCRIPTION
- there was probably some intent to use them for tests or for testing
  `tsdx test` in the past, but they're currently wholly unused
  - and get picked up by Jest unless ignored or otherwise skipped