### PR TITLE
(clean): remove all references to --define

### DIFF
--- a/src/babelPluginTsdx.ts
+++ b/src/babelPluginTsdx.ts
@@ -73,10 +73,6 @@ export const babelPluginTsdx = babelPlugin.custom(() => ({
           name: 'babel-plugin-transform-rename-import',
           replacements,
         },
-        isTruthy(customOptions.defines) && {
-          name: 'babel-plugin-transform-replace-expressions',
-          replace: customOptions.defines,
-        },
         {
           name: 'babel-plugin-transform-async-to-promises',
           inlineHelpers: true,

--- a/src/createRollupConfig.ts
+++ b/src/createRollupConfig.ts
@@ -183,7 +183,6 @@ export async function createRollupConfig(
           targets: opts.target === 'node' ? { node: '8' } : undefined,
           extractErrors: opts.extractErrors,
           format: opts.format,
-          // defines: opts.defines,
         },
       }),
       opts.env !== undefined &&


### PR DESCRIPTION
- these have been commented out for a long time now
- babel-plugin-transform-replace-expressions also isn't in the
  dependencies either

- they were borrowed from microbundle afaik, but both support babelrc
  nowadays; I think these defines are better configured there than
  with flags anyway