### PR TITLE
(fix): remove faulty tsconfig.json include of test dir

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,5 +4,7 @@ module.exports = {
   testPathIgnorePatterns: [
     '/node_modules/', // default
     '<rootDir>/templates/', // don't run tests in the templates
+    '<rootDir>/test/.*/fixtures/', // don't run tests in fixtures
+    '<rootDir>/stage-.*/', // don't run tests in auto-generated (and auto-removed) test dirs
   ],
 };

--- a/src/deprecated.ts
+++ b/src/deprecated.ts
@@ -22,7 +22,9 @@ export async function moveTypes() {
       'rootDir to "./src".\n' +
       'TSDX has deprecated setting tsconfig.compilerOptions.rootDir to ' +
       '"./" as it caused buggy output for declarationMaps and occassionally ' +
-      'for type declarations themselves.'
+      'for type declarations themselves.\n' +
+      'You may also need to change your include to remove "test", which also ' +
+      'caused declarations to be unnecessarily created for test files.'
   );
 
   try {

--- a/templates/basic/tsconfig.json
+++ b/templates/basic/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["src", "types", "test"],
+  "include": ["src", "types"],
   "compilerOptions": {
     "module": "esnext",
     "lib": ["dom", "esnext"],

--- a/templates/react-with-storybook/tsconfig.json
+++ b/templates/react-with-storybook/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["src", "types", "test"],
+  "include": ["src", "types"],
   "compilerOptions": {
     "module": "esnext",
     "lib": ["dom", "esnext"],

--- a/templates/react/tsconfig.json
+++ b/templates/react/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["src", "types", "test"],
+  "include": ["src", "types"],
   "compilerOptions": {
     "module": "esnext",
     "lib": ["dom", "esnext"],

--- a/test/e2e/fixtures/build-default/test/some-test.test.ts
+++ b/test/e2e/fixtures/build-default/test/some-test.test.ts
@@ -1,0 +1,3 @@
+// this is to test that .test/.spec files in the test/ dir are excluded
+
+// and that rootDir: './src' doesn't error with test/ files

--- a/test/e2e/fixtures/build-default/test/testUtil.ts
+++ b/test/e2e/fixtures/build-default/test/testUtil.ts
@@ -1,0 +1,4 @@
+// this is to test that test helper files in the test/ dir are excluded
+// i.e. files in test/ that don't have a .spec/.test suffix
+
+// and that rootDir: './src' doesn't error with test/ files

--- a/test/e2e/fixtures/build-default/types/blar.d.ts
+++ b/test/e2e/fixtures/build-default/types/blar.d.ts
@@ -1,0 +1,3 @@
+// this is to test that rootDir: './src' doesn't error with types/ files
+
+// and that declaration files aren't re-output in dist/

--- a/test/e2e/tsdx-build-default.test.js
+++ b/test/e2e/tsdx-build-default.test.js
@@ -31,6 +31,15 @@ describe('tsdx build :: zero-config defaults', () => {
     expect(output.code).toBe(0);
   });
 
+  it("shouldn't compile files in test/ or types/", () => {
+    const output = execWithCache('node ../dist/index.js build');
+
+    expect(shell.test('-d', 'dist/test/')).toBeFalsy();
+    expect(shell.test('-d', 'dist/types/')).toBeFalsy();
+
+    expect(output.code).toBe(0);
+  });
+
   it('should create the library correctly', () => {
     const output = execWithCache('node ../dist/index.js build');
 


### PR DESCRIPTION
- `include` means all files that should be compiled, and the test dir
  should definitely not be compiled
  - this was causing issues where declarations were being output into
    dist/ for all files in test/
    - that shouldn't happen and it means `build` was unnecessarily
      slowed down in order to process test/ files
    - default `exclude` that was added of *.spec/*.test files,
      originally for co-located tests, ended up making most test/ dir
      files excluded too, but not, say, test utils that don't have a
      .spec or .test suffix

- this was also causing errors with the `rootDir: './src'` change as
  the test/ dir is outside of the rootDir
  - problem wasn't the rootDir, but that the test/ dir shouldn't be
    compiled or processed in any way

(test): ensure test/*.test.ts and test/*.ts files are correctly
excluded and don't have declarations generated
- and that they don't error with rootDir: './src'

(test): ensure types/*.d.ts don't error with rootDir and don't have
declarations re-generated either
- n.b. tsc won't re-generate them either, they don't get copied to
  outDir, this isn't new or different behavior

(env/test): Jest shouldn't run / should ignore tests inside of fixtures


<hr>

Fixes #638 , the root cause of it, and adds tests for this.

Effectively reverts #226 . I haven't been able to reproduce #225 / #84 in my VS Code, but maybe that's because I have it configured a little differently?
Would like to add VS Code integration tests so there's an automated way to check that it works independently on CI without any configuration (and so I don't have to attempt and fail to test this on my own machine).
But `tsc --noEmit` at least, indeed doesn't output errors in `test/` anymore. `tsdx lint` still does.
Per my comments in #638 if this and the VS Code integration are problematic, we should move this to a `tsconfig.build.json` and then have a plain `tsconfig.json` that extends from it and changes `include` to `'./'` so everything is type-checked.