### PR TITLE
(format): format all files, not just src/ and test/

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+/node_modules/
+dist/

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,10 +1,8 @@
 module.exports = {
   testEnvironment: 'node',
-  testMatch: [
-    '<rootDir>/**/*(*.)@(test).[tj]s?(x)'
-  ],
+  testMatch: ['<rootDir>/**/*(*.)@(test).[tj]s?(x)'],
   testPathIgnorePatterns: [
     '/node_modules/', // default
-    '<rootDir>/templates/' // don't run tests in the templates
-  ]
-}
+    '<rootDir>/templates/', // don't run tests in the templates
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "prepare": "tsc -p tsconfig.json",
     "build": "tsc -p tsconfig.json",
     "lint": "yarn build && yarn lint:post-build",
-    "lint:post-build": "node dist/index.js lint src test --ignore-pattern 'test/e2e/fixtures/lint'",
+    "lint:post-build": "node dist/index.js lint ./ --ignore-pattern 'test/e2e/fixtures/lint'",
     "test": "yarn build && yarn test:post-build",
     "test:post-build": "node dist/index.js test",
     "start": "tsc -p tsconfig.json --watch",


### PR DESCRIPTION
- fix jest.config.js formatting errors
- ignore dist/ (and the default of node_modules)

Split out from #646 where I realized when editing the `jest.config.js` that it wasn't being linted/formatted.

This also starts another conversation -- shouldn't `tsdx lint` or the scripts in the templates default to `'./'` and not just `src test`? `src test` already misses things like `example` and `stories` as well as `.eslintrc.js`, `jest.config.js`, and any other root files or root directories.
Personally I think it should default to `'./'` and we'll need an `.eslintignore` or symlink to `.gitignore` for the templates then too since we need to ignore all `node_modules` (at root and at `example`) as well as `dist/`.
See also #517 that ESLint by default does not use `.gitignore` for ignores for some reason