### PR TITLE
(fix): fix output file name after build

### DIFF
--- a/src/createRollupConfig.ts
+++ b/src/createRollupConfig.ts
@@ -35,7 +35,7 @@ export async function createRollupConfig(
     opts.minify !== undefined ? opts.minify : opts.env === 'production';
 
   const outputName = [
-    `${paths.appDist}/${safePackageName(opts.name)}`,
+    `${paths.appDist}/${safePackageName(opts.outputName)}`,
     opts.format,
     opts.env,
     shouldMinify ? 'min' : '',

--- a/src/index.ts
+++ b/src/index.ts
@@ -290,10 +290,9 @@ prog
     if (!opts.noClean) {
       await cleanDistFolder();
     }
-    opts.name = opts.name || appPackageJson.name;
     opts.input = await getInputs(opts.entry, appPackageJson.source);
     if (opts.format.includes('cjs')) {
-      await writeCjsEntryFile(opts.name);
+      await writeCjsEntryFile(opts.outputName);
     }
 
     type Killer = execa.ExecaChildProcess | null;
@@ -393,7 +392,7 @@ prog
     await cleanDistFolder();
     const logger = await createProgressEstimator();
     if (opts.format.includes('cjs')) {
-      const promise = writeCjsEntryFile(opts.name).catch(logError);
+      const promise = writeCjsEntryFile(opts.outputName).catch(logError);
       logger(promise, 'Creating entry file');
     }
     try {
@@ -421,6 +420,7 @@ async function normalizeOpts(opts: WatchOpts): Promise<NormalizedOpts> {
   return {
     ...opts,
     name: opts.name || appPackageJson.name,
+    outputName: appPackageJson.name,
     input: await getInputs(opts.entry, appPackageJson.source),
     format: opts.format.split(',').map((format: string) => {
       if (format === 'es') {

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,6 +28,7 @@ export interface WatchOpts extends BuildOpts {
 export interface NormalizedOpts
   extends Omit<WatchOpts, 'name' | 'input' | 'format'> {
   name: string;
+  outputName: string;
   input: string[];
   format: [ModuleFormat, ...ModuleFormat[]];
 }
@@ -35,6 +36,8 @@ export interface NormalizedOpts
 export interface TsdxOptions extends SharedOpts {
   // Name of package
   name: string;
+  // Output name of package
+  outputName: string;
   // path to file
   input: string;
   // Environment


### PR DESCRIPTION
Fixed output file name after build to use the name of `package.json` instead of the passed name if the `--name` option is passed.

Currently, the output file name uses the value passed by the `--name` option, as follows:

1. Create a library using hyphen: `npx tsdx create my-lib`
2. Build with `--name` option: `yarn build --name MyLib --format esm,cjs,umd`
3. Check `dist` dir: `tree dist/`

```
dist/
├── index.d.ts
├── index.js
├── mylib.cjs.development.js
├── mylib.cjs.development.js.map
├── mylib.cjs.production.min.js
├── mylib.cjs.production.min.js.map
├── mylib.esm.js
├── mylib.esm.js.map
├── mylib.umd.development.js
├── mylib.umd.development.js.map
├── mylib.umd.production.min.js
└── mylib.umd.production.min.js.map
```

I think the output file name should use the name of `package.json` instead of the name passed with the `--name` option, as follows:

```
dist/
├── index.d.ts
├── index.js
├── my-lib.cjs.development.js
├── my-lib.cjs.development.js.map
├── my-lib.cjs.production.min.js
├── my-lib.cjs.production.min.js.map
├── my-lib.esm.js
├── my-lib.esm.js.map
├── my-lib.umd.development.js
├── my-lib.umd.development.js.map
├── my-lib.umd.production.min.js
└── my-lib.umd.production.min.js.map
```

In fact, in ReactDOM, it is `react-dom.development.js`, not` reactdom.development.js`.


