### PR TITLE
(clean): remove redundant set of watch opts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -290,8 +290,6 @@ prog
     if (!opts.noClean) {
       await cleanDistFolder();
     }
-    opts.name = opts.name || appPackageJson.name;
-    opts.input = await getInputs(opts.entry, appPackageJson.source);
     if (opts.format.includes('cjs')) {
       await writeCjsEntryFile(opts.name);
     }


### PR DESCRIPTION
- another thing that was missed in #130
- these sets are already done in normalizeOpts, no need to redundantly
  perform them again
  - fortunately this wasn't inconsistent with normalizeOpts, so no
    harm done before this got out

Co-Authored-By: Kotaro Sugawara <kotarella1110@gmail.com>

<hr>

Follow-up to https://github.com/jaredpalmer/tsdx/pull/669#discussion_r405222739 and https://github.com/jaredpalmer/tsdx/pull/130#issuecomment-610716225