### PR TITLE
(deps/clean): remove unused @types/ms devDep

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,6 @@
     "@types/eslint": "^6.1.2",
     "@types/execa": "^0.9.0",
     "@types/fs-extra": "^8.0.0",
-    "@types/ms": "^0.7.30",
     "@types/node": "^13.1.0",
     "@types/ora": "^3.2.0",
     "@types/react": "^16.9.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1251,11 +1251,6 @@
   resolved "https://registry.yarnpkg.com/@types/mri/-/mri-1.1.0.tgz#66555e4d797713789ea0fefdae0898d8170bf5af"
   integrity sha512-fMl88ZoZXOB7VKazJ6wUMpZc9QIn+jcigSFRf2K/rrw4DcXn+/uGxlWX8DDlcE7JkwgIZ7BDH+JgxZPlc/Ap3g==
 
-"@types/ms@^0.7.30":
-  version "0.7.31"
-  resolved "https://registry.yarnpkg.com/@types/ms/-/ms-0.7.31.tgz#31b7ca6407128a3d2bbc27fe2d21b345397f6197"
-  integrity sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==
-
 "@types/node@*":
   version "12.12.14"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.14.tgz#1c1d6e3c75dba466e0326948d56e8bd72a1903d2"


### PR DESCRIPTION
- `ms` dep was removed in df39d021440a5d2a, but not its
  @types/ counterpart
- @types/ms was added in 70337566f88421 which also removed the only
  usage of `ms`
  - and the function that it was in that was removed was unused anyway

<hr>

`ms` was removed in #57, but not `@types/ms` .
`@types/ms` was added in #54 which also removed the only usage of `ms`.