### PR TITLE
(fix/deps): semver should be a dep, not a devDep

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "rollup-plugin-terser": "^5.1.2",
     "rollup-plugin-typescript2": "^0.26.0",
     "sade": "^1.4.2",
+    "semver": "^7.1.1",
     "shelljs": "^0.8.3",
     "tiny-glob": "^0.2.6",
     "ts-jest": "^24.0.2",
@@ -118,7 +119,6 @@
     "react-dom": "^16.13.0",
     "react-is": "^16.13.0",
     "rollup-plugin-postcss": "^2.5.0",
-    "semver": "^7.1.1",
     "styled-components": "^5.0.1",
     "tiny-invariant": "^1.1.0",
     "tiny-warning": "^1.0.3"


### PR DESCRIPTION
- it's used in `tsdx create`, definitely not a devDep
  - surprised that this hasn't been reported as a bug before, but
    probably because it's a subdep of another dep so it finds its way
    into most folks' node_modules anyway

<hr>

Oversight from #433 where it was added as a devDep instead of a dep.
Looks like that only made it into v0.13, so a v0.13.x patch is enough to fix

Incidental finding while upgrading other deps to Node 10+ (<tbd insert PR ref here>)