### PR TITLE
(optim/fix): only emit type declarations once

### DIFF
--- a/src/createBuildConfigs.ts
+++ b/src/createBuildConfigs.ts
@@ -35,9 +35,9 @@ export async function createBuildConfigs(
   );
 
   return await Promise.all(
-    allInputs.map(async (options: TsdxOptions) => {
+    allInputs.map(async (options: TsdxOptions, index: number) => {
       // pass the full rollup config to tsdx.config.js override
-      const config = await createRollupConfig(options);
+      const config = await createRollupConfig(options, index);
       return tsdxConfig.rollup(config, options);
     })
   );

--- a/src/createRollupConfig.ts
+++ b/src/createRollupConfig.ts
@@ -146,7 +146,6 @@ export async function createRollupConfig(
       },
       typescript({
         typescript: ts,
-        cacheRoot: `./node_modules/.cache/tsdx/${opts.format}/`,
         tsconfig: opts.tsconfig,
         tsconfigDefaults: {
           exclude: [

--- a/src/createRollupConfig.ts
+++ b/src/createRollupConfig.ts
@@ -24,7 +24,8 @@ const errorCodeOpts = {
 let shebang: any = {};
 
 export async function createRollupConfig(
-  opts: TsdxOptions
+  opts: TsdxOptions,
+  outputNum: number
 ): Promise<RollupOptions> {
   const findAndRecordErrorCodes = await extractErrors({
     ...errorCodeOpts,
@@ -170,6 +171,10 @@ export async function createRollupConfig(
           compilerOptions: {
             // TS -> esnext, then leave the rest to babel-preset-env
             target: 'esnext',
+            // don't output declarations more than once
+            ...(outputNum > 0
+              ? { declaration: false, declarationMap: false }
+              : {}),
           },
         },
         check: !opts.transpileOnly,

--- a/src/deprecated.ts
+++ b/src/deprecated.ts
@@ -21,27 +21,14 @@ export async function moveTypes() {
     '[tsdx]: Your rootDir is currently set to "./". Please change your ' +
       'rootDir to "./src".\n' +
       'TSDX has deprecated setting tsconfig.compilerOptions.rootDir to ' +
-      '"./" as it caused buggy output for declarationMaps and occassionally ' +
-      'for type declarations themselves.\n' +
+      '"./" as it caused buggy output for declarationMaps and more.\n' +
       'You may also need to change your include to remove "test", which also ' +
       'caused declarations to be unnecessarily created for test files.'
   );
 
-  try {
-    // Move the typescript types to the base of the ./dist folder
-    await fs.copy(appDistSrc, paths.appDist, {
-      overwrite: true,
-    });
-  } catch (err) {
-    // ignore errors about the destination dir already existing or files not
-    // existing as those always occur for some reason, re-throw any other
-    // unexpected failures
-    // NOTE: these errors mean that sometimes files don't get moved properly,
-    // meaning that it's buggy / unreliable (see console.warn above)
-    if (err.code !== 'EEXIST' && err.code !== 'ENOENT') {
-      throw err;
-    }
-  }
-
+  // Move the typescript types to the base of the ./dist folder
+  await fs.copy(appDistSrc, paths.appDist, {
+    overwrite: true,
+  });
   await fs.remove(appDistSrc);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -401,11 +401,13 @@ prog
           async (inputOptions: RollupOptions & { output: OutputOptions }) => {
             let bundle = await rollup(inputOptions);
             await bundle.write(inputOptions.output);
-            await deprecated.moveTypes();
           }
         )
         .catch((e: any) => {
           throw e;
+        })
+        .then(async () => {
+          await deprecated.moveTypes();
         });
       logger(promise, 'Building modules');
       await promise;


### PR DESCRIPTION
- every other emission is just a duplicate -- no need to spend compute
  time to make duplicates
  - even for the upcoming multi-entry, the same types are emitted for
    each entry as the compiler just emits types for everything in the
    `tsconfig` `include`

- fixes a long-standing bug with the deprecated moveTypes() function
  that would occasionally cause types to not be properly output
  - this was actually due to moveTypes() being run multiple times in
    parallel (as well as the types themselves being emitted multiple
    times in parallel)
    - hence the EEXIST and ENOENT filesystem errors being thrown, as
      that directory was being changed multiple times in parallel
      - race conditions, fun!
  - now they're only emitted once and only moved once, so no problems!

- also fixes a bug with an initial version of multi-entry where if an
  entry in a subdir of src/ were added, e.g. src/foo/bar, the entire
  tree of type declarations would get output into dist/foo/src/*.d.ts
  - alternatively, could call `moveTypes()` with an arg for each entry,
    but there's no need since all declarations get produced the first
    time around anyway
  - similar bug occurred with an initial version of `--preserveModules`
    that used separate format directories

Also threw in another TS optimization here with the `cacheRoot` change that's along the same lines but slightly different of a change.

<hr>

This is extracted out of #367 's 14b539763ef21, but is a better version in a few ways:
1. Doesn't have issues with `declarationMap`s as they've also been set to `false`. Otherwise would get errors / test failures that you can't have `declarationMap`s without `declaration`s
    - Better testing around this nowadays revealed this bug
1. `: undefined` still overrode some `declaration`/`declarationMap` settings, also causing errors / test failures, so changed this to not set either on the first emission
1. `moveTypes()` was moved into a `then` of the `asyncro()` so that it's still part of the progress estimation.

The bugs this fixed in #367 and by extension #535 should no longer be present anyway since #367 switched/improved to use Rollup's code-splitting instead of a separate build & bundle per entry and #535 will need to be updated to use the same `output.entryFileNames` as a later version of #367 used instead of using separate format dirs.

<hr>

I also realized that this might fix the bugs with `moveTypes()` that gave us so many CI issues prior to #504 very recently in https://github.com/jaredpalmer/tsdx/pull/500#issuecomment-605530750.
And indeed this does fix those bugs, hence the removals of the error throwaways and a change in the deprecation message by a bit (it's still a problematic option, with another caveat other than those listed that `moveTypes()` doesn't apply to custom `declarationDir`s, though that could be fixed). I tested that this was the case by changing `rootDir` to `./` in every test fixture and running tests a couple of times and no errors were thrown anymore!

<hr>

The `cacheRoot` optimization is also related to #328 / #329. And might make #618 obsolete.