### PR TITLE
(docs): add Jest and ESLint subsections to Customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Despite all the recent hype, setting up a new TypeScript (x React) library can b
   - [Rollup](#rollup)
     - [Example: Adding Postcss](#example-adding-postcss)
   - [Babel](#babel)
+  - [Jest](#jest)
+  - [ESLint](#eslint)
 - [Inspiration](#inspiration)
   - [Comparison to Microbundle](#comparison-to-microbundle)
 - [API Reference](#api-reference)
@@ -373,7 +375,15 @@ module.exports = {
 
 ### Babel
 
-You can add your own `.babelrc` to the root of your project and TSDX will **merge** it with its own babel transforms (which are mostly for optimization).
+You can add your own `.babelrc` to the root of your project and TSDX will **merge** it with [its own Babel transforms](./src/babelPluginTsdx.ts) (which are mostly for optimization), putting any new presets and plugins at the end of its list.
+
+### Jest
+
+You can add your own `jest.config.js` to the root of your project and TSDX will **shallow merge** it with [its own Jest config](./src/createJestConfig.ts).
+
+### ESLint
+
+You can add your own `.eslintrc.js` to the root of your project and TSDX will **deep merge** it with [its own ESLint config](./src/createEslintConfig.ts).
 
 ## Inspiration
 
@@ -455,7 +465,7 @@ Examples
 
 ### `tsdx test`
 
-This runs Jest v24.x. See [https://jestjs.io](https://jestjs.io) for options. For example, if you would like to run in watch mode, you can run `tsdx test --watch`. So you could set up your `package.json` `scripts` like:
+This runs Jest v24.x, forwarding all CLI flags to it. See [https://jestjs.io](https://jestjs.io) for options. For example, if you would like to run in watch mode, you can run `tsdx test --watch`. So you could set up your `package.json` `scripts` like:
 
 ```json
 {


### PR DESCRIPTION
- while the docs do say these are run fairly directly, recently folks
  seem to be particularly confused about how to configure Jest
  - so explicitly mention `jest.config.js` and `.eslintrc.js` to make
    that a bit more clear
    - don't mention `package.json` options as I think that should be
      implicitly implied enough now
      - and because ESLint config works a bit differently in the two
        cases (see [existing issue](https://github.com/jaredpalmer/tsdx/issues/514))
  - and more explicitly say that all `tsdx test` flags are forwarded to
    Jest

- also add links to "its own config" for each of the Babel, Jest, and
  ESLint subsections so people can look at the source quickly if they
  want
  - the Babel one is a bit harder to read though

- and specify the merge behavior for each, i.e. shallow or deep
  - and the ordering when it comes to Babel, as order matters there

<hr>

To help with issues like #695 and https://github.com/jaredpalmer/tsdx/issues/692#issuecomment-616745580 as I guess it's not clear enough that you can do this already
Also specifies merge behavior of Babel since #543 is a thing