### PR TITLE
(fix): templates should not have baseUrl or paths set

### DIFF
--- a/templates/basic/tsconfig.json
+++ b/templates/basic/tsconfig.json
@@ -13,10 +13,6 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "moduleResolution": "node",
-    "baseUrl": "./",
-    "paths": {
-      "*": ["src/*", "node_modules/*"]
-    },
     "jsx": "react",
     "esModuleInterop": true
   }

--- a/templates/react-with-storybook/example/tsconfig.json
+++ b/templates/react-with-storybook/example/tsconfig.json
@@ -13,7 +13,6 @@
     "preserveConstEnums": true,
     "sourceMap": true,
     "lib": ["es2015", "es2016", "dom"],
-    "baseUrl": ".",
     "types": ["node"]
   }
 }

--- a/templates/react-with-storybook/tsconfig.json
+++ b/templates/react-with-storybook/tsconfig.json
@@ -13,11 +13,6 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "moduleResolution": "node",
-    "baseUrl": "./",
-    "paths": {
-      "@": ["./"],
-      "*": ["src/*", "node_modules/*"]
-    },
     "jsx": "react",
     "esModuleInterop": true
   }

--- a/templates/react/example/tsconfig.json
+++ b/templates/react/example/tsconfig.json
@@ -13,7 +13,6 @@
     "preserveConstEnums": true,
     "sourceMap": true,
     "lib": ["es2015", "es2016", "dom"],
-    "baseUrl": ".",
     "types": ["node"]
   }
 }

--- a/templates/react/tsconfig.json
+++ b/templates/react/tsconfig.json
@@ -13,10 +13,6 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "moduleResolution": "node",
-    "baseUrl": "./",
-    "paths": {
-      "*": ["src/*", "node_modules/*"]
-    },
     "jsx": "react",
     "esModuleInterop": true
   }

--- a/test/e2e/fixtures/build-default/tsconfig.json
+++ b/test/e2e/fixtures/build-default/tsconfig.json
@@ -11,10 +11,6 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "moduleResolution": "node",
-    "baseUrl": "./",
-    "paths": {
-      "*": ["src/*", "node_modules/*"]
-    },
     "jsx": "react",
     "esModuleInterop": true
   },

--- a/test/e2e/fixtures/build-invalid/tsconfig.json
+++ b/test/e2e/fixtures/build-invalid/tsconfig.json
@@ -11,10 +11,6 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "moduleResolution": "node",
-    "baseUrl": "./",
-    "paths": {
-      "*": ["src/*", "node_modules/*"]
-    },
     "jsx": "react",
     "esModuleInterop": true
   },

--- a/test/e2e/fixtures/build-withTsconfig/tsconfig.base.json
+++ b/test/e2e/fixtures/build-withTsconfig/tsconfig.base.json
@@ -13,10 +13,6 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "moduleResolution": "node",
-    "baseUrl": "./",
-    "paths": {
-      "*": ["src/*", "node_modules/*"]
-    },
     "jsx": "react",
     "esModuleInterop": false
   },

--- a/test/integration/fixtures/build-options/tsconfig.json
+++ b/test/integration/fixtures/build-options/tsconfig.json
@@ -11,10 +11,6 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "moduleResolution": "node",
-    "baseUrl": "./",
-    "paths": {
-      "*": ["src/*", "node_modules/*"]
-    },
     "jsx": "react",
     "esModuleInterop": true
   },

--- a/test/integration/fixtures/build-withBabel/tsconfig.json
+++ b/test/integration/fixtures/build-withBabel/tsconfig.json
@@ -11,10 +11,6 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "moduleResolution": "node",
-    "baseUrl": "./",
-    "paths": {
-      "*": ["src/*", "node_modules/*"]
-    },
     "jsx": "react",
     "esModuleInterop": true
   },

--- a/test/integration/fixtures/build-withConfig/tsconfig.json
+++ b/test/integration/fixtures/build-withConfig/tsconfig.json
@@ -11,10 +11,6 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "moduleResolution": "node",
-    "baseUrl": "./",
-    "paths": {
-      "*": ["src/*", "node_modules/*"]
-    },
     "jsx": "react",
     "esModuleInterop": true
   },


### PR DESCRIPTION
- there are many issues about TS path aliases not fully "working", so
  they should be removed from the templates until they are completely
  "working"
  - instead of shipping templates with a partially "broken" and
    confusing configuration enabled
  - especially confusing to users because editors will auto-complete
    with the absolute path instead of the relative path
  - and the fact that these paths are unresolved at build or test time
    means that it's not understood that this is "broken" until later in
    the process

- this is a *very* common misconception with TS users that `paths`
  rewrites/transforms imports during compilation, but it actually does
  not change any absolute paths to relative, it leaves them as is
  - it just resolves type information to help on platforms that import
    differently
    - basically, it's somewhat of a legacy option, but folks think it's
      used for aliases and does transforms
      - and folks seem to want it to work that way too
      - it actually does the reverse, it supports the usage of
        aliases/import rewrites elsewhere
  - unfortunately this misconception made its way into the very first
    template, causing lots of confusion and issues reported since

- so `paths` isn't "broken" per se, it just doesn't do what people
  think it does (including template authors)
  - well it *is* broken for standard TSDX usage out-of-the-box
    - since TSDX doesn't output for platforms where it makes sense
      out-of-the-box

- as a result, for aliases to be fully supported by TSDX, we'd have to
  add some sort of transformation(s) for build, test, and lint
  - until then this shouldn't be in the templates
    - but don't give an error on it because there are
      methods/"workarounds" to support aliasing/import rewrites using
      the configuration in `paths`
      - and if one is using import rewrites, `paths` is necessary for
        TS to not give errors

- also removes an inconsistency in the Storybook template that used
  "@/*" as an alias, even though the other templates didn't have that
  - while this is a supported alias by some libraries in the community,

  - oversight in code review when Storybook templates were added and
    caused some confusion for users

- also removes these options from all test fixtures

<hr>

Long time coming for this one, these have been in the codebase since the very first template was added in 9010ecbda5 and have caused much confusion since then.

Fixes the root cause of #91, #699, #516, #139, #133, etc.

Full support for aliases, i.e. an import rewrite/transform mechanism, will be added eventually, keep an eye on #91 for that.