### PR TITLE
Upgrade engines.node to >=12 in package.json for basic template

### DIFF
--- a/src/templates/basic.ts
+++ b/src/templates/basic.ts
@@ -13,7 +13,7 @@ const basicTemplate: Template = {
     typings: `dist/index.d.ts`,
     files: ['dist', 'src'],
     engines: {
-      node: '>=10',
+      node: '>=12',
     },
     scripts: {
       start: 'tsdx watch',


### PR DESCRIPTION
The `engines.node` field should match the version of node we are testing against in CI: https://github.com/jaredpalmer/tsdx/blob/21893b8e498985879bb6665dba279cf4853aabec/templates/basic/.github/workflows/main.yml

This change doesn't apply to the other templates

Thanks for the awesome package! You saved me a ton of time for sure! <3