### PR TITLE
fix: preserve package name (fix #714)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -218,7 +218,11 @@ prog
       // Install deps
       process.chdir(projectPath);
       const safeName = safePackageName(pkg);
-      const pkgJson = generatePackageJson({ name: safeName, author });
+      const pkgJson = generatePackageJson({
+        safeName,
+        author,
+        pkg,
+      });
 
       const nodeVersionReq = getNodeEngineRequirement(pkgJson);
       if (

--- a/src/templates/utils/index.ts
+++ b/src/templates/utils/index.ts
@@ -1,17 +1,20 @@
 import { Template } from '../template';
 
 interface ProjectArgs {
-  name: string;
+  safeName: string;
   author: string;
+  pkg: string;
 }
+
 export const composePackageJson = (template: Template) => ({
-  name,
+  safeName,
   author,
+  pkg,
 }: ProjectArgs) => {
   return {
     ...template.packageJson,
-    name,
+    name: pkg,
     author,
-    module: `dist/${name}.esm.js`,
+    module: `dist/${safeName}.esm.js`,
   };
 };


### PR DESCRIPTION
Preserve inputted package name of `name` field in package.json.

## Before

input @byted/test,
```json
name: test
```

## After

input @byted/test,
```json
name: @byted/test
```