### PR TITLE
github: disable blank issues without an issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false


### PR DESCRIPTION
## Description

- apparently there's a button you can press to skip using an issue
  template, which means some issues come in that can be low quality,
  confusing what the request is, don't list versions, etc
  - so disable this button and require a template, which will also make
    the writer think about whether their issue is a feature or bug
    - (if neither, perhaps StackOverflow, Discussions, etc is a better
      option than filing an issue)

- follows the official docs from
  https://docs.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository#configuring-the-template-chooser,
  which instructs to set blank_issues_enabled to false to disable the
  button / option

## Tags

#761 pointed out to me that one could click a button for a blank issue which was what led me to find these docs and this config option. Should help pare down on issues labeled with ["removed issue template"](https://github.com/formium/tsdx/issues?q=is%3Aissue+label%3A%22removed+issue+template%22+) more broadly