### PR TITLE
greenkeeper: remove website from greenkeeper config

### DIFF
--- a/greenkeeper.json
+++ b/greenkeeper.json
@@ -3,8 +3,7 @@
     "default": {
       "packages": [
         "package.json",
-        "templates/react/example/package.json",
-        "website/package.json"
+        "templates/react/example/package.json"
       ]
     }
   }


### PR DESCRIPTION
## Description

- website doesn't need vulnerability updates because it has no forms or
  real attack surface and it is not a published library that others
  depend on
  - greenkeeper wasn't just for vulnerability updates though; automatic
    dep updates aren't necessary either as no one depends on it and it's
    not frequently used (until recently was last updated ~6 months ago)

- greenkeeper is no longer a thing, but not sure if Snyk is perhaps
  using the same config, so try changing it to reduce all these
  unnecessary, duplicative, and buggy Snyk PRs
  - based on the website / docs, it doesn't sound like this will change
    anything and this file should probably be deleted, but since I don't
    have access to Snyk to be able to change settings, this is all I
    can try

## Tags

c.f. #807 .. and #806 and #804 and #809 and #812 and #813 and probably more...