### PR TITLE
github: use envinfo for getting versions in issue reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -25,13 +25,14 @@ assignees: ''
 
 ### Your environment
 
-<!-- PLEASE FILL THIS OUT -->
+<!--
+  PLEASE RUN THIS COMMAND INSIDE YOUR PROJECT:
 
-| Software         | Version(s) |
-| ---------------- | ---------- |
-| TSDX           |
-| TypeScript       |
-| Browser          |
-| npm/Yarn         |
-| Node             | 
-| Operating System |
+  npx envinfo --system OS --browsers --binaries --npmPackages tsdx,typescript --npmGlobalPackages tsdx,typescript
+
+  AND PASTE ITS CONTENTS BELOW INSIDE THE CODE SNIPPET vvvvvvvvv
+-->
+
+```text
+
+```


### PR DESCRIPTION
## Description

- replace the version table with a copy+paste this `envinfo` command,
  copy back the output
  - saw `nyc` using this about a year ago and thought it was super
    useful; finally got around to adding it here
    - https://github.com/istanbuljs/nyc/blame/00c3b3440a5b2ffe11b9c19ae4e08ad2f5b70e33/.github/ISSUE_TEMPLATE.md#L20-L23
    - exact language was modified and updated from
      https://github.com/styled-components/styled-components/blame/53bc31f/.github/ISSUE_TEMPLATE.md#L34
      as TSDX does not have its own envinfo preset
      - perhaps worth creating one?
    - code snippet inspired from
      https://github.com/facebook/jest/blame/4d32070/.github/ISSUE_TEMPLATE/bug.md#L35

- this should make reporting versions zero-effort and thereby
  significantly decrease non-reporting by making the hard thing easy
  - have had a few places that didn't report and version was *very*
    relevant to the issue
  - also have had several that reported "latest" or used carets, which
    lacks posterity or is confusing

## Tags

I actually suggested using this myself in #167, which was one of my first issues here