### PR TITLE
Fix ESM output name issue

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -457,8 +457,8 @@ if (process.env.NODE_ENV === 'production') {
 
 function writeMjsEntryFile(name: string) {
   const contents = `
-export { default } from './${name}.min.mjs';
-export * from './${name}.min.mjs';
+export { default } from './${safePackageName(name)}.min.mjs';
+export * from './${safePackageName(name)}.min.mjs';
   `;
   return fs.outputFile(path.join(paths.appDist, 'index.mjs'), contents);
 }


### PR DESCRIPTION
While using a namespaced package name like `@companyname/package-name` the ESM build output was referring to the invalid file path. This PR will fix the issue.