### PR TITLE
Add storybook-static to gitignore

### DIFF
--- a/templates/react-with-storybook/gitignore
+++ b/templates/react-with-storybook/gitignore
@@ -3,3 +3,4 @@
 node_modules
 .cache
 dist
+storybook-static


### PR DESCRIPTION
When building from a `react-with-storybook` and running `yarn build-storybook`, the built storybook files gets shown as "untracked files."

IMO, these files shouldn’t be committed into a repository:

```
$ ls
0.6af89d43.iframe.bundle.js                           2.ac2b29f4.iframe.bundle.js                           favicon.ico
0.6af89d43.iframe.bundle.js.LICENSE.txt               3.8a076da5.iframe.bundle.js                           iframe.html
0.6af89d43.iframe.bundle.js.map                       5.23ef655b5acff6eac8ad.manager.bundle.js              index.html
0.e5489f12ab94aa497491.manager.bundle.js              6.d2f96bcf3b11b0f1a44b.manager.bundle.js              main.3fb8cb266a67ec5355cf.manager.bundle.js
0.e5489f12ab94aa497491.manager.bundle.js.LICENSE.txt  7.4a59445e.iframe.bundle.js                           main.3fb8cb266a67ec5355cf.manager.bundle.js.LICENSE.txt
1.50a64abc.iframe.bundle.js                           7.4a59445e.iframe.bundle.js.LICENSE.txt               main.be617d58.iframe.bundle.js
1.50a64abc.iframe.bundle.js.LICENSE.txt               7.4a59445e.iframe.bundle.js.map                       project.json
1.50a64abc.iframe.bundle.js.map                       7.a1c5467faea0833b53d1.manager.bundle.js              runtime~main.8e5cf3a9715a0d32d390.manager.bundle.js
1.7d0dd704b26935d06a04.manager.bundle.js              8.083c2f57.iframe.bundle.js                           runtime~main.d011358d.iframe.bundle.js
10.398dd7a0522c1ff2b3a8.manager.bundle.js             8.65ec2749796fb05c258c.manager.bundle.js              vendors~main.7c47903ea43e951c3707.manager.bundle.js
10.5a6abb49.iframe.bundle.js                          8.65ec2749796fb05c258c.manager.bundle.js.LICENSE.txt  vendors~main.7c47903ea43e951c3707.manager.bundle.js.LICENSE.txt
10.5a6abb49.iframe.bundle.js.LICENSE.txt              9.acd0ef9064e0667433ac.manager.bundle.js              vendors~main.efa84851.iframe.bundle.js
10.5a6abb49.iframe.bundle.js.map                      9.acd0ef9064e0667433ac.manager.bundle.js.LICENSE.txt  vendors~main.efa84851.iframe.bundle.js.LICENSE.txt
11.1093823a.iframe.bundle.js                          9.de4755f0.iframe.bundle.js                           vendors~main.efa84851.iframe.bundle.js.map
```

So they should be added to gitignore.