### PR TITLE
Add information about the project not being maintained anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> **This project is not maintained anymore. See issues [#1058](https://github.com/jaredpalmer/tsdx/issues/1058) and [#1065](https://github.com/jaredpalmer/tsdx/issues/1065) to find replacement libraries and some reasons why.**
+
 ![tsdx](https://user-images.githubusercontent.com/4060187/56918426-fc747600-6a8b-11e9-806d-2da0b49e89e4.png)
 
 [![Blazing Fast](https://badgen.now.sh/badge/speed/blazing%20%F0%9F%94%A5/green)](https://npm.im/tsdx) [![Blazing Fast](https://badgen.now.sh/badge/speed/blazing%20%F0%9F%94%A5/green)](https://npm.im/tsdx) [![Blazing Fast](https://badgen.now.sh/badge/speed/blazing%20%F0%9F%94%A5/green)](https://npm.im/tsdx) [![Discord](https://img.shields.io/discord/769256827007139912.svg?style=flat-square)](https://discord.gg/pJSg287)


### PR DESCRIPTION
I'm still getting notifications on #1065 even though i innocently created this issue about 18 months ago. Along with this PR I'm (finally, long time overdue) unsubscribing to this repo.

My only wish for this PR is that it's clear for everyone that this project is no longer maintained and that people save time instead of searching in issues and reading a long thread to understand what could be obvious from the main page.

It'd be nice if it was merged, for the community around tsdx, turborepo and vercel.