### PR TITLE
docs: update version references from 1.0 to 2.0

### DIFF
--- a/.changeset/initial-release.md
+++ b/.changeset/initial-release.md
@@ -2,7 +2,7 @@
 "tsdx": major
 ---
 
-Initial 1.0.0 release - complete rewrite with modern Rust-based tooling
+Initial 2.0.0 release - complete rewrite with modern Rust-based tooling
 
 - Bundling with bunchee
 - Testing with vitest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-TSDX is a zero-config CLI for TypeScript package development. Version 1.0 is a complete rewrite using modern Rust-based tooling: bunchee (bundling), vitest (testing), oxlint (linting), and oxfmt (formatting).
+TSDX is a zero-config CLI for TypeScript package development. Version 2.0 is a complete rewrite using modern Rust-based tooling: bunchee (bundling), vitest (testing), oxlint (linting), and oxfmt (formatting).
 
 ## Development Commands
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,12 +1,12 @@
-# Migration Guide: TSDX v0.x to v1.0
+# Migration Guide: TSDX v0.x to v2.0
 
-This guide helps you migrate from the original TSDX (v0.x) to the modern TSDX 1.0.
+This guide helps you migrate from the original TSDX (v0.x) to the modern TSDX 2.0.
 
 ## What's Changed
 
-TSDX 1.0 is a complete rewrite that replaces the original toolchain with modern, high-performance alternatives:
+TSDX 2.0 is a complete rewrite that replaces the original toolchain with modern, high-performance alternatives:
 
-| Old (v0.x) | New (v1.0) | Why |
+| Old (v0.x) | New (v2.0) | Why |
 |------------|------------|-----|
 | Rollup + Babel | [bunchee](https://github.com/huozhi/bunchee) | Zero-config, SWC-powered, faster |
 | Jest | [vitest](https://vitest.dev/) | Vite-native, faster, Jest-compatible |

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Zero-config CLI for TypeScript package development.
 
 Modern TypeScript library development, simplified. TSDX provides a zero-config CLI that helps you develop, test, and publish TypeScript packages with ease.
 
-> **TSDX 1.0** is a complete rewrite using modern, high-performance Rust-based tooling. See the [Migration Guide](./MIGRATION.md) if upgrading from v0.x
+> **TSDX 2.0** is a complete rewrite using modern, high-performance Rust-based tooling. See the [Migration Guide](./MIGRATION.md) if upgrading from v0.x
 
 ## Features
 
@@ -241,7 +241,7 @@ The `package.json` exports field is configured automatically:
 
 ## Tool Stack
 
-TSDX 1.0 uses modern, high-performance tools:
+TSDX 2.0 uses modern, high-performance tools:
 
 | Tool | Purpose | Performance |
 |------|---------|-------------|
@@ -374,7 +374,7 @@ Contributions are welcome! Please see [CONTRIBUTING.md](./CONTRIBUTING.md) for g
 
 ## Acknowledgments
 
-TSDX 1.0 is built on the shoulders of giants:
+TSDX 2.0 is built on the shoulders of giants:
 
 - [bunchee](https://github.com/huozhi/bunchee) by Jiachi Liu
 - [vitest](https://vitest.dev/) by the Vitest team

--- a/website/app/(home)/page.tsx
+++ b/website/app/(home)/page.tsx
@@ -263,7 +263,7 @@ export default function HomePage() {
             Powered by Modern Tools
           </h2>
           <p className="text-lg text-fd-muted-foreground mb-12">
-            TSDX 1.0 is built on the fastest, most modern tools in the ecosystem.
+            TSDX 2.0 is built on the fastest, most modern tools in the ecosystem.
           </p>
 
           <div className="grid grid-cols-2 md:grid-cols-4 gap-6">

--- a/website/content/docs/index.mdx
+++ b/website/content/docs/index.mdx
@@ -7,8 +7,8 @@ description: Zero-config CLI for TypeScript package development
 
 **TSDX is a zero-config CLI that helps you develop, test, and publish modern TypeScript packages** with ease—so you can focus on your awesome new library and not waste another afternoon on configuration.
 
-<Callout type="info" title="TSDX 1.0">
-  TSDX 1.0 is a complete rewrite using modern, high-performance Rust-based tooling. See the [Migration Guide](/docs/migration) if upgrading from v0.x.
+<Callout type="info" title="TSDX 2.0">
+  TSDX 2.0 is a complete rewrite using modern, high-performance Rust-based tooling. See the [Migration Guide](/docs/migration) if upgrading from v0.x.
 </Callout>
 
 ## Features
@@ -23,7 +23,7 @@ description: Zero-config CLI for TypeScript package development
 
 ## Tool Stack
 
-TSDX 1.0 uses modern, high-performance tools:
+TSDX 2.0 uses modern, high-performance tools:
 
 | Tool | Purpose | Performance |
 |------|---------|-------------|

--- a/website/content/docs/migration.mdx
+++ b/website/content/docs/migration.mdx
@@ -1,17 +1,17 @@
 ---
 title: Migration Guide
-description: Migrating from TSDX v0.x to v1.0
+description: Migrating from TSDX v0.x to v2.0
 ---
 
 # Migration Guide
 
-This guide helps you migrate from the original TSDX (v0.x) to the modern TSDX 1.0.
+This guide helps you migrate from the original TSDX (v0.x) to the modern TSDX 2.0.
 
 ## What's Changed
 
-TSDX 1.0 is a complete rewrite that replaces the original toolchain with modern, high-performance alternatives:
+TSDX 2.0 is a complete rewrite that replaces the original toolchain with modern, high-performance alternatives:
 
-| Old (v0.x) | New (v1.0) | Why |
+| Old (v0.x) | New (v2.0) | Why |
 |------------|------------|-----|
 | Rollup + Babel | [bunchee](https://github.com/huozhi/bunchee) | Zero-config, SWC-powered, faster |
 | Jest | [vitest](https://vitest.dev/) | Vite-native, faster, Jest-compatible |


### PR DESCRIPTION
Skip version 1.0 and jump to 2.0 across all documentation and markdown
files including README, CLAUDE.md, MIGRATION.md, changeset, and website docs.