### PR TITLE
chore: update tsdx to version 2.0.0 and add vitest as a dev dependency

### DIFF
--- a/templates/basic/package.json
+++ b/templates/basic/package.json
@@ -40,7 +40,8 @@
   },
   "devDependencies": {
     "@types/node": "^22.10.2",
-    "tsdx": "^1.0.0",
-    "typescript": "^5.7.2"
+    "tsdx": "^2.0.0",
+    "typescript": "^5.7.2",
+    "vitest": "^4.0.16"
   }
 }

--- a/templates/react/package.json
+++ b/templates/react/package.json
@@ -50,7 +50,8 @@
     "jsdom": "^25.0.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "tsdx": "^1.0.0",
-    "typescript": "^5.7.2"
+    "tsdx": "^2.0.0",
+    "typescript": "^5.7.2",
+    "vitest": "^4.0.16"
   }
 }


### PR DESCRIPTION
This pull request updates the development dependencies in the `package.json` files for both the `basic` and `react` templates. The most significant changes are upgrading the `tsdx` package and adding `vitest` as a new dependency.

Dependency updates:

* Upgraded `tsdx` from version `^1.0.0` to `^2.0.0` in both `templates/basic/package.json` and `templates/react/package.json`. 
* Added `vitest` version `^4.0.16` to the devDependencies in both `templates/basic/package.json` and `templates/react/package.json`. 